### PR TITLE
Feature/nima app.rb structure

### DIFF
--- a/ruby-sinatra/app.rb
+++ b/ruby-sinatra/app.rb
@@ -16,8 +16,13 @@ class WhoknowsApp < Sinatra::Base
   set :views, File.expand_path('../views', __FILE__)
 
   # Session configuration (nødvendig for login/logout)
-  enable :sessions
-  set :session_secret, ENV.fetch('SESSION_SECRET') { 'development_secret_key' }
+  # enable :sessions
+  # set :session_secret, ENV.fetch('SESSION_SECRET') { 'development_secret_key' }
+
+   # Test - no DB needed - http://localhost:4567/hello
+  get "/hello" do
+    "Sinatra says Hello World!"
+  end
 
   ################################################################################
   # Before/After Request Handlers
@@ -72,7 +77,7 @@ class WhoknowsApp < Sinatra::Base
   # API Routes (JSON Responses)
   ###############################################################################
 
-  # GET /api/search - Search API endpoint
+  # GET /api/search - Search API endpoint - http://localhost:4567/api/search?q=test
   # OpenAPI: operationId "search_api_search_get"
   get '/api/search' do
     content_type :json

--- a/ruby-sinatra/views/index.erb
+++ b/ruby-sinatra/views/index.erb
@@ -1,1 +1,3 @@
 <!-- Frontpage -->
+
+Frontpage from of GET / - Root/Search page on localhost:5467


### PR DESCRIPTION
## Description
Made the template for `app.rb` so it matches the structure of `app.py`. 
`app.rb` is set up with comments to match OpenAPI from `whoknows-spec.json` located in `docs/openapi`-folder

Existing code in `app.rb` is still present.

## Related Issue
Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Rewrite (Python → Ruby)
- [ ] Documentation
- [ ] DevOps / Infrastructure
- [ ] Chore

## Changes Made
- Corrected response format in `/api/search` 
from `{ search_results: search_results }.to_json` → `{ data: search_results }.to_json`
so it matches the OpenAPI from `whoknkows-spec.json`
- Added text in `index.erb` just for visual confirmation that `get '/' do` is working

## How to Test
Run `app.rb` and check these endpoints
1. [http://localhost:4567/hello](http://localhost:4567/hello)
2. [http://localhost:4567](http://localhost:4567)
3. [http://localhost:4567/api/search?q=test](http://localhost:4567/api/search?q=test)

## Checklist
- [x] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)  ⚠️ **!!!NO - BUT SHOULD!!!**
- [ ] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)
