### PR TITLE
REWRITE: Opdateret user model og require field i app.rb

### DIFF
--- a/ruby-sinatra/app.rb
+++ b/ruby-sinatra/app.rb
@@ -4,7 +4,8 @@ require 'sinatra'
 require 'sinatra/activerecord'
 require 'json'
 require_relative 'config/environment'
-require_relative 'models/page'        
+require_relative 'models/page' 
+require_relative 'models/user'       
 # require_relative 'models/user' # Uncomment når User model er oprettet
 
 

--- a/ruby-sinatra/models/user.rb
+++ b/ruby-sinatra/models/user.rb
@@ -1,1 +1,26 @@
-# ActiveRecord models
+require 'digest'
+
+# User-model - mapper til 'users'-tabellen via ActiveRecord.
+# ActiveRecord finder automatisk tabellen ud fra klassenavnet (User => users).
+class User < ActiveRecord::Base
+
+  # Validations - svarer til if/elsif-tjek i Flask's /api/register route
+  validates :username, presence: { message: "You have to enter a username" },
+                       uniqueness: { message: "The username is already taken" }
+
+  validates :email, presence: { message: "You have to enter a valid email address" },
+                    format: { with: /@/, message: "You have to enter a valid email address" }
+
+  validates :password, presence: { message: "You have to enter a password" }
+
+  # MD5-hashing - samme som Flask's hashlib.md5()
+  # Klassemetode (self.) - kaldes med User.hash_password("test")
+  def self.hash_password(password)
+    Digest::MD5.hexdigest(password)
+  end
+
+  # Instansmetode - kaldes paa et user-objekt: user.verify_password("test")
+  def verify_password(plain_password)
+    self.password == User.hash_password(plain_password)
+  end
+end


### PR DESCRIPTION
## Description
Opretter User-modellen i models/user.rb med ActiveRecord.
Modellen mapper til den eksisterende users-tabel og inkluderer
validations samt MD5 password-hashing kompatibelt med Flask-appen.

## Related Issue
Closes #28

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Rewrite (Python → Ruby)
- [ ] Documentation
- [ ] DevOps / Infrastructure
- [ ] Chore

## Changes Made
- Erstattet placeholder i models/user.rb med fuld ActiveRecord-model
- Tilføjet validations for username, email og password
- Tilføjet hash_password og verify_password metoder (MD5, kompatibelt med Flask)
- Tilføjet require_relative 'models/user' i app.rb

## How to Test
1. Start Sinatra-appen med bundle exec ruby app.rb
2. Åben en Ruby-konsol: bundle exec irb -r ./app.rb
3. Test at User.find_by(username: "admin") returnerer admin-brugeren fra databasen
4. Test at User.hash_password("password") returnerer "5f4dcc3b5aa765d61d8327deb882cf99"

## Checklist
- [x] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)