### PR TITLE
REWRITE: oprettet html-termplate og kald for /register

### DIFF
--- a/ruby-sinatra/app.rb
+++ b/ruby-sinatra/app.rb
@@ -65,7 +65,9 @@ class WhoknowsApp < Sinatra::Base
 
   # GET /register - Registration page
   # OpenAPI: operationId "serve_register_page_register_get"
+ # GET /register - viser registrerings-formularen
   get '/register' do
+    erb :register, locals: { error: nil }
   end
 
   # GET /login - Login page

--- a/ruby-sinatra/views/register.erb
+++ b/ruby-sinatra/views/register.erb
@@ -1,1 +1,23 @@
-<!-- Register page -->
+<!-- Registrerings-side. Sender formular til POST /api/register -->
+
+<h2>Sign Up</h2>
+
+<% if error %>
+  <div class="error"><strong>Error:</strong> <%= error %></div>
+<% end %>
+
+<form action="/api/register" method="POST">
+  <dl>
+    <dt>Username:</dt>
+    <dd><input type="text" name="username" size="30"></dd>
+    <dt>E-Mail:</dt>
+    <dd><input type="text" name="email" size="30"></dd>
+    <dt>Password:</dt>
+    <dd><input type="password" name="password" size="30"></dd>
+    <dt>Password <small>(repeat)</small>:</dt>
+    <dd><input type="password" name="password2" size="30"></dd>
+  </dl>
+  <div class="actions">
+    <input type="submit" value="Sign Up">
+  </div>
+</form>


### PR DESCRIPTION
## Description
Tilfojer GET /register routen i app.rb og udfylder
views/register.erb med registrerings-formularen.

## Related Issue
Closes #27

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Rewrite (Python → Ruby)
- [ ] Documentation
- [ ] DevOps / Infrastructure
- [ ] Chore

## Changes Made
- Tilfojet get '/register' route i app.rb
- Erstattet placeholder i views/register.erb med registrerings-formular
- Formularen sender POST til /api/register (implementeres i #22)

## How to Test
1. Start appen med bundle exec ruby app.rb
2. Gaa til http://localhost:4567/register i browseren
3. Verificer at formularen vises med felter for username, email, password og password2

## Checklist
- [x] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)