### PR TITLE
REWRITE: Register API, OBS: Kræver user før merge

### DIFF
--- a/docs/openapi/ruby-sinatra-spec.json
+++ b/docs/openapi/ruby-sinatra-spec.json
@@ -4,8 +4,94 @@
     "title": "WhoKnows",
     "version": "0.1.0",
     "description": "Ruby/Sinatra implementation - WIP"
-},
-"paths":{
-
-}
+  },
+  "paths": {
+    "/api/register": {
+      "post": {
+        "summary": "Register",
+        "operationId": "register_api_register_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": ["username", "email", "password"],
+                "properties": {
+                  "username": { "type": "string" },
+                  "email": { "type": "string" },
+                  "password": { "type": "string" },
+                  "password2": { "type": "string" }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Registration successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AuthResponse": {
+        "type": "object",
+        "properties": {
+          "statusCode": {
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "description": "HTTP status code"
+          },
+          "message": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "description": "Response message"
+          }
+        }
+      },
+      "HTTPValidationError": {
+        "type": "object",
+        "properties": {
+          "detail": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            }
+          }
+        }
+      },
+      "ValidationError": {
+        "type": "object",
+        "required": ["loc", "msg", "type"],
+        "properties": {
+          "loc": {
+            "type": "array",
+            "items": {
+              "anyOf": [{ "type": "string" }, { "type": "integer" }]
+            }
+          },
+          "msg": { "type": "string" },
+          "type": { "type": "string" }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Description
Tilføjer POST /api/register routen i app.rb.
Modtager form-data (username, email, password, password2),
validerer input via User-modellens validations, hasher password
og opretter brugeren i databasen. Returnerer AuthResponse ved
success (200) og HTTPValidationError ved fejl (422).

## Related Issue
Closes #22
Depends on #28

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Rewrite (Python -> Ruby)
- [ ] Documentation
- [ ] DevOps / Infrastructure
- [ ] Chore

## Changes Made
- Tilføjet post '/api/register' route i app.rb
- Success returnerer AuthResponse (statusCode + message)
- Fejl returnerer HTTPValidationError med detail-array (422)
- Konverterer ActiveRecord validation-fejl til ValidationError format
- Opdateret ruby-sinatra-spec.json med endpoint + AuthResponse,
  HTTPValidationError og ValidationError schemas

## How to Test
1. Start appen med bundle exec ruby app.rb
2. Test success:
   curl -X POST http://localhost:4567/api/register \
     -d "username=testuser&email=test@example.com&password=secret&password2=secret"
   Forventet: {"statusCode":200,"message":"You were successfully registered..."}
3. Test password mismatch:
   curl -X POST http://localhost:4567/api/register \
     -d "username=test2&email=t@t.com&password=a&password2=b"
   Forventet: 422 med {"detail":[...]}
4. Test manglende username:
   curl -X POST http://localhost:4567/api/register \
     -d "email=t@t.com&password=a&password2=a"
   Forventet: 422 med detail der nævner username
5. Test duplikeret username (send request fra punkt 2 igen)

## Checklist
- [ ] Tested locally
- [x] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)