### PR TITLE
Added readme section for use of robocop

### DIFF
--- a/ruby-sinatra/README.md
+++ b/ruby-sinatra/README.md
@@ -183,7 +183,22 @@ Output:
 ```
 http://localhost:4567
 ```
+---
 
+## Code Quality
+
+### RuboCop (linting)
+
+The project uses [RuboCop](https://rubocop.org/) for style enforcement and static analysis.
+```bash
+# Run locally
+bundle exec rubocop
+
+# Auto-fix safe offenses
+bundle exec rubocop -a
+```
+
+Configuration is in `.rubocop.yml`. RuboCop runs automatically in CI on push and pull requests.
 ---
 
 ## Migration-strategi


### PR DESCRIPTION
## Description
Add Code Quality section to the Ruby/Sinatra README documenting how to run RuboCop locally and noting its CI integration.

## Related Issue
Closes #68
Related to #65 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [x] Documentation
- [ ] DevOps / Infrastructure
- [ ] Chore

## Changes Made
- Added "Code Quality" section to `ruby-sinatra/README.md` with RuboCop usage instructions

## How to Test
1. Open `ruby-sinatra/README.md`
2. Verify the new Code Quality section is present with correct commands
3. Confirm `bundle exec rubocop` and `bundle exec rubocop -a` instructions are accurate

## Checklist
- [x] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)