### PR TITLE
Made it possible to login with hashed password as well

### DIFF
--- a/ruby-sinatra/models/user.rb
+++ b/ruby-sinatra/models/user.rb
@@ -21,7 +21,11 @@ class User < ActiveRecord::Base
   end
 
   # Instansmetode - kaldes paa et user-objekt: user.verify_password("test")
-  def verify_password?(plain_password)
-    password == User.hash_password(plain_password)
+  # def verify_password?(plain_password)
+  #  password == User.hash_password(plain_password)
+  # end
+
+  def verify_password?(input)
+    password == User.hash_password(input) || password == input
   end
 end


### PR DESCRIPTION
## Description
Login with hashed-version of password.


## Related Issue
Closes #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [ ] Documentation
- [ ] DevOps / Infrastructure
- [ ] Chore

## Changes Made
- Allows user to login with plain text password as well as the hashed version.

## How to Test (locally)
1. curl -X POST http://127.0.0.1:4567/api/login -d "username=YOUR_USERNAME&password=YOUR_PLAIN_TEXT_PASSWORD" -H "Content-Type: application/x-www-form-urlencoded"

2. curl -X POST http://127.0.0.1:4567/api/login -d "username=YOUR_USERNAME&password=YOUR_HASHED_PASSWORD" -H "Content-Type: application/x-www-form-urlencoded"

3. 

## Checklist
- [x] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)
