### PR TITLE
Add missing legacy HTML IDs to index.erb and document decision

### DIFF
--- a/docs/choices-and-challenges/Choices and Challenges.md
+++ b/docs/choices-and-challenges/Choices and Challenges.md
@@ -1,7 +1,7 @@
 # Choices and Challenges
 
 **Written by:** Andreas, Nima & Sofie
- **Updated:** 15th February 2026 - 09.52
+ **Updated:** 19th Marts 2026 - 10.47
 
 ------
 
@@ -861,15 +861,63 @@ Den rapporterede fejl (Style/RescueModifier) findes ikke i den aktuelle kodebase
 
 ---
 
-## 
+## HTML ID-kompatibilitet med legacy frontend
+
+### Context
+Underviser kører en simulation der automatisk klikker rundt på projektets frontend. Simulationen er skrevet mod legacy Flask-projektet og bruger specifikke HTML `id`-attributter til at finde og interagere med elementer på siden (søgefelt, søgeknap, resultatcontainer).
+
+### Challenge
+- Ruby/Sinatra rewritet havde ikke de samme `id`-attributter som legacy Flask-projektet på søgesiden
+- Legacy Flask brugte `id="search-input"`, `id="search-button"` og `id="results"` i `search.html`
+- Vores `index.erb` (som håndterer samme route `/`) manglede alle tre IDs
+- Simulationen ville fejle fordi den ikke kunne finde de forventede elementer
+
+**Overvejede patterns:**
+- Lade simulationen fejle og afvente feedback fra underviser
+- Tilpasse vores IDs til at matche legacy-koden
+
+### Choice
+**Beslutning:** Tilføj de tre manglende `id`-attributter til `index.erb` så de matcher legacy-koden præcist
+
+**Implementering:**
+
+```markdown
+- id="search-input"  tilføjet til <input type="text" name="q">
+- id="search-button" tilføjet til <button type="submit">
+- id="results"       tilføjet til <div class="search-results"> (class bevaret)
+```
+
+**Rationale:**
+- Simulationen er en ekstern afhængighed vi ikke kontrollerer – vi tilpasser os den
+- Ændringen er rent additiv (IDs tilføjes, intet fjernes eller omdøbes)
+- CSS påvirkes ikke: eksisterende class-selectors (`.search-results`, `input[name="q"]`) fungerer stadig
+
+**Fordele:**
+- Simulationen kan interagere korrekt med vores frontend
+- Ingen visuel eller funktionel ændring for rigtige brugere
+- CSS-styling forbliver uændret
+
+**Ulemper:**
+- Vi er bundet til legacy-projektets navngivningskonventioner for disse tre elementer
+- Hvis legacy-projektet ændrer sine IDs skal vi følge med
+
+**Retrospektiv:** (Opdateres løbende)
+-
+
+**Læring:**
+- Ekstern simulationsafhængighed kræver at frontend-kontrakter (HTML IDs, classes) behandles som en del af API-kontrakten
+- Additiv tilgang (tilføj ID, bevar class) er den mindst risikable måde at opnå kompatibilitet uden at bryde eksisterende styling
+---
+
+##
 
 ### Context
 
 ### Challenge
-- 
+-
 
 **Overvejede patterns:**
-- 
+-
 
 ### Choice
 **Beslutning:**
@@ -884,13 +932,13 @@ Den rapporterede fejl (Style/RescueModifier) findes ikke i den aktuelle kodebase
 -
 
 **Fordele:**
-- 
+-
 
 **Ulemper:**
-- 
+-
 
 **Retrospektiv:** (Opdateres løbende)
-- 
+-
 
 **Læring:**
-- 
+-

--- a/ruby-sinatra/views/index.erb
+++ b/ruby-sinatra/views/index.erb
@@ -1,8 +1,8 @@
 <!-- Frontpage from of GET / - Root/Search page on localhost:4567 -->
 
 <form class="search-form" action="/" method="get">
-  <input type="text" name="q" value="<%= @q %>" placeholder="Search...">
-  <button type="submit">Search</button>
+  <input id="search-input" type="text" name="q" value="<%= @q %>" placeholder="Search...">
+  <button id="search-button" type="submit">Search</button>
   <div class="custom-select">
     <button type="button" class="custom-select-toggle" onclick="toggleDropdown()">English <span class="arrow">&#9662;</span></button>
     <ul class="custom-select-menu" id="language-menu">
@@ -31,7 +31,7 @@
 </script>
 
 <% if @results && @results.any? %>
-  <div class="search-results">
+  <div id="results" class="search-results">
     <p class="results-count"><%= @results.length %> result<%= @results.length == 1 ? '' : 's' %> for "<%= @q %>"</p>
     <% @results.each do |page| %>
       <div class="result-card">


### PR DESCRIPTION
## Description
Corrected `id="..."`'s in `index.erb` that were not matching the legacy code. 
Document the decision in Choices and Challenges.

## Related Issue
Closes #95

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [x] Documentation
- [ ] DevOps / Infrastructure
- [x] Chore

## Changes Made
- Added `id="search-input"` to the search text input in `index.erb`                                                                          
- Added `id="search-button"` to the search submit button in `index.erb`                                                                      
- Added `id="results"` to the results container in `index.erb`
- Documented the decision in Choices and Challenges 

## How to Test
   - [ ] Verify search input, button, and results container have correct IDs in browser dev tools
   - [ ] Verify search functionality still works as expected
   - [ ] Verify CSS styling is unchanged

## Checklist
- [ ] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [ ] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved a compatibility issue where HTML element identifiers required for legacy frontend integration were missing. Essential identifiers have been added to form controls and results containers while preserving all existing functionality, styles, and behavior.

* **Documentation**
  * Documented HTML compatibility considerations, challenges encountered during the rewrite, and specific solutions implemented to ensure seamless integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->