### PR TITLE
94 bug find the missing registered user from anders plotserver

### DIFF
--- a/docs/choices-and-challenges/Choices and Challenges.md
+++ b/docs/choices-and-challenges/Choices and Challenges.md
@@ -938,8 +938,16 @@ before do
     request.body.rewind
     begin
       json_body = JSON.parse(request.body.read, symbolize_names: false)
-      json_body.each { |k, v| params[k] ||= v }
+      # ||= sikrer at eksisterende params ikke overskrives af JSON body
+      if json_body.is_a?(Hash)
+        json_body.each { |k, v| params[k] ||= v }
+      else
+        content_type :json
+        halt 400, { detail: [{ loc: ['body'], msg: 'Expected JSON object', type: 'type_error' }] }.to_json
+      end
     rescue JSON::ParserError
+      # Returnér 400 ved malformed JSON frem for at fejle stille
+      content_type :json
       halt 400, { detail: [{ loc: ['body'], msg: 'Invalid JSON', type: 'parse_error' }] }.to_json
     end
   end
@@ -956,7 +964,8 @@ end
 - Alle nuværende og fremtidige routes får automatisk JSON support
 - Routes forbliver uændrede og læsbare
 - Understøtter både form-encoded og JSON uden at vælge én standard
-- Malformed JSON returnerer 400 med en beskrivende fejlbesked
+- Malformed JSON returnerer 400 med en beskrivende fejlbesked og korrekt `Content-Type` header
+- JSON arrays og primitiver afvises med 400 frem for at fejle med `NoMethodError`
 - Begrænset til POST requests, så GET routes ikke påvirkes unødigt
 - Koden er synlig og forståelig direkte i app.rb
 
@@ -971,12 +980,14 @@ end
 
 **Retrospektiv:** (Opdateres løbende)
 - Fejlen stod på fra første deployment den 26. februar uden at blive opdaget, fordi vi ikke havde monitoring på response codes
+- Coderabbit identificerede to edge cases under PR review: manglende type validering og manglende `Content-Type` header på fejlresponses
 
 **Læring:**
 - Flask og Sinatra håndterer content negotiation forskelligt - Sinatra er mere eksplicit
 - Monitoring af response codes er nødvendigt for at opdage denne type fejl tidligt
 - 422 fra simulatoren er et bedre signal end "manglende bruger" - fejlkoden pegede på valideringsfejl, ikke autentificeringsfejl
 - Rack middleware og applikationslaget løser samme problem på forskelligt abstraktionsniveau - valget afhænger af hvor meget kontrol man har brug for
+- Automatisk PR review med Coderabbit fangede edge cases som ikke var åbenlyse under implementation
 
 ---
 

--- a/ruby-sinatra/app.rb
+++ b/ruby-sinatra/app.rb
@@ -54,9 +54,15 @@ class WhoknowsApp < Sinatra::Base
       begin
         json_body = JSON.parse(request.body.read, symbolize_names: false)
         # ||= sikrer at eksisterende params ikke overskrives af JSON body
-        json_body.each { |k, v| params[k] ||= v }
+        if json_body.is_a?(Hash)
+          json_body.each { |k, v| params[k] ||= v }
+        else
+          content_type :json
+          halt 400, { detail: [{ loc: ['body'], msg: 'Expected JSON object', type: 'type_error' }] }.to_json
+        end
       rescue JSON::ParserError
         # Returnér 400 ved malformed JSON frem for at fejle stille
+        content_type :json
         halt 400, { detail: [{ loc: ['body'], msg: 'Invalid JSON', type: 'parse_error' }] }.to_json
       end
     end


### PR DESCRIPTION
## Description
Sinatra does not automatically parse JSON request bodies into `params`, unlike Flask. This caused all login and register attempts from Anders' simulator to return 422, as the simulator sends requests as JSON. This fix adds centralized JSON body parsing in the `before` block with explicit error handling for malformed JSON.

## Related Issue
Closes #94 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [x] Documentation
- [ ] DevOps / Infrastructure
- [ ] Chore

## Changes Made
- Added JSON body parsing in the existing `before` block, limited to POST requests
- Malformed JSON returns 400 with a descriptive error message instead of failing silently
- Updated Choices & Challenges with decision rationale and alternatives considered

## How to Test
1. Send a POST request to `/api/login` with `Content-Type: application/json` and a valid username/password
2. Verify the response is 200 and returns `"You were logged in"`
3. Send a POST request with malformed JSON and verify the response is 400

## Checklist
- [ ] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [ ] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)

## To do
Once merged, the next step is to open a PR from `development` → `main` to get the fix into production.

After that is merged and the CI/CD pipeline has deployed successfully, we will set up a Telegram bot notification script on the Azure server to monitor login attempts and alert us if 422 errors reappear.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed POST requests failing when JSON bodies were not merged into request params; added validation to return a 400 with a structured JSON error for malformed JSON.

* **Documentation**
  * Added detailed documentation on JSON body parsing behavior, the chosen centralized mitigation, alternative approaches, and retrospective learnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->