### PR TITLE
168 chore auto login user after registration

### DIFF
--- a/ruby-sinatra/app.rb
+++ b/ruby-sinatra/app.rb
@@ -206,9 +206,10 @@ class WhoknowsApp < Sinatra::Base
     )
 
     if user.save
+      session[:user_id] = user.id
       # Svarer til Flask's "You were successfully registered..."
       status 200
-      { statusCode: 200, message: 'You were successfully registered and can login now' }.to_json
+      { statusCode: 200, message: 'You were successfully registered' }.to_json
     else
       # .errors.full_messages.first giver foerste validation-fejl
       # f.eks. "You have to enter a username"

--- a/ruby-sinatra/views/register.erb
+++ b/ruby-sinatra/views/register.erb
@@ -33,7 +33,7 @@
     .then(response => response.json())
     .then(data => {
       if (data.statusCode === 200) {
-        window.location.href = '/login';
+        window.location.href = '/';
       } else {
         const msg = data.detail ? data.detail[0].msg : data.message;
         document.getElementById('error-text').textContent = msg;


### PR DESCRIPTION
## Description
Keep the user logged in our registration.


## Related Issue
Closes #168 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [ ] Documentation
- [ ] DevOps / Infrastructure
- [x] Chore

## Changes Made
- Added user session in post register method in app.rb: 
´ if user.save
      session[:user_id] = user.id
      # Svarer til Flask's "You were successfully registered..."
      status 200
      { statusCode: 200, message: 'You were successfully registered' }.to_json
    else´
- Removed /login in register.erb to navigate the user to the landing page index.erb after registration line 36:
´if (data.statusCode === 200) {
        window.location.href = '/';´

## How to Test
1. Run the application and register in the browser locally.


## Checklist
- [x] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users are now automatically logged in upon successful registration, eliminating the need for a separate login step.
  * After registration, users are redirected directly to the home page instead of the login page.
  * Updated registration success message for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->