### PR TITLE
172 devops harden the system   security scanning of code containers website and server

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,7 +70,7 @@ jobs:
         uses: docker/scout-action@v1
         with:
           command: cves
-          image: ghcr.io/sobr0002/monkknows:latest
+          image: ghcr.io/${{ env.DOCKER_GITHUB_USERNAME }}/monkknows:latest
           only-severities: critical,high
           exit-code: false
           write-comment: false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,7 +58,7 @@ jobs:
 
       # Scan the local image before pushing — blocks vulnerable images from reaching GHCR
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947e0f18c8ea63fd80e
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           image-ref: ghcr.io/${{ env.DOCKER_GITHUB_USERNAME }}/monkknows:latest
           format: table

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,6 +65,18 @@ jobs:
           exit-code: '1'
           severity: CRITICAL,HIGH
 
+      # Docker Scout — informational scan (reports findings, does not block pipeline)
+      - name: Docker Scout CVE scan
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: ghcr.io/sobr0002/monkknows:latest
+          only-severities: critical,high
+          exit-code: false
+          write-comment: false
+          summary: true
+
+
       # Push the same scanned image — no rebuild
       - name: Push Docker image to GHCR
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Log in to GHCR
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7519a1c44
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ghcr.io
           username: ${{ env.DOCKER_GITHUB_USERNAME }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,7 +67,7 @@ jobs:
 
       # Docker Scout — informational scan (reports findings, does not block pipeline)
       - name: Docker Scout CVE scan
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@f8c776824083494ab0d56b8105ba2ca85c86e4de
         with:
           command: cves
           image: ghcr.io/${{ env.DOCKER_GITHUB_USERNAME }}/monkknows:latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -127,6 +127,7 @@ jobs:
             nginx.conf \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/opt/whoknows/app/nginx.conf
 
+      # CD-CD
       - name: Deploy on server
         run: |
           ssh -i ~/.ssh/ssh_key \

--- a/.github/workflows/cf.yml
+++ b/.github/workflows/cf.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   owasp-zap:
+
     name: OWASP ZAP Baseline Scan
     runs-on: ubuntu-latest
 

--- a/docs/choices-and-challenges/Choices and Challenges.md
+++ b/docs/choices-and-challenges/Choices and Challenges.md
@@ -1301,41 +1301,30 @@ Desuden:
 
 ------
 
-## Sikr systemet med snyk
+## Sikr systemet med snyk og Docker Scout
 
 ### Context
+Snyk og Docker Scout blev evalueret som supplement til eksisterende sikkerhedsværktøjer i CI/CD-pipeline.
 
 ### Challenge
--
+- Vurdere om Snyk og Docker Scout tilbyder merværdi oven på eksisterende sikkerhedsværktøjer.
 
 ### Choice
 **Beslutning:**
-- snyk fravalgt pga. flg.:
-    - gratis version har begrænsninger og kræver ekstern konto
-    - bundler-audit og brakeman er allerede integreret og dækker hhv. dependency og code security
-    - snyk ville tilføje et dashboard, alerts og PR-kommentarer, hvor bundler-audit rapporterer i terminal og lader
-      pipeline fejle ved sårbarheder
-  
-**Implementering:**
+Snyk fravalgt — bundler-audit og brakeman dækker samme behov uden ekstern afhængighed.
+Docker Scout valgt som supplement til Trivy i CD-pipeline.
 
-```markdown
-
-```
+- Bundler-audit scanner dependencies mod Ruby Advisory Database
+- Brakeman udfører statisk kodeanalyse for sikkerhedssårbarheder
+- Snyk kræver ekstern konto og har begrænsninger på gratis tier
+- Snyk ville primært tilføje dashboard og alerts — ikke øget sikkerhedsdækning for et Ruby Sinatra-projekt
+- Trivy blokerer allerede pipeline ved CRITICAL/HIGH fund
+- Docker Scout tilføjes som informativ scanning med anden database end Trivy — ingen ekstra secrets da GHCR-login 
+genbruges
 
 **Rationale:**
--
-
-**Fordele:**
--
-
-**Ulemper:**
--
-
-**Retrospektiv:** (Opdateres løbende)
--
-
-**Læring:**
--
+- To specialiserede Ruby-værktøjer foretrækkes frem for Snyk
+  Docker Scout og Trivy supplerer hinanden da de slår op i forskellige CVE-databaser
 
 ------
 

--- a/docs/choices-and-challenges/Choices and Challenges.md
+++ b/docs/choices-and-challenges/Choices and Challenges.md
@@ -1341,6 +1341,57 @@ Desuden:
 
 ------
 
+## Observatory resultater 
+
+### Context
+Projektet kører som en Ruby Sinatra-mikroservice bag Nginx på monkknows.dk. Mozilla Observatory blev kørt som del af 
+sikkerhedsreviewet: observatory.mozilla.org
+
+### Challenge
+Observatory-scanningen afslørede tre kritiske sikkerhedsproblemer der tilsammen kostede −85 point:
+- Ingen CSP-header (XSS-angreb muligt)
+- Session-cookie uden Secure-flag (session hijacking muligt)
+- Ingen HSTS (bruger kan ramme HTTP første besøg)
+
+### Choice
+**Beslutning:** Adressér alle tre kritiske fund via nginx.conf og sikr at cookies sættes korrekt i Sinatra-appen.
+
+**Implementering:**
+
+```markdown
+Rettelser foretaget:
+1. CSP-header tilføjet i nginx.conf
+2. HSTS-header tilføjet i nginx.conf
+3. Referrer-Policy tilføjet i nginx.conf
+4. Secure-flag på session-cookie i Sinatra-app
+
+Eksisterende og velfungerende:
+- X-Content-Type-Options: nosniff
+- X-Frame-Options: SAMEORIGIN
+- HTTPS-redirect
+- CORS ikke eksponeret
+```
+
+**Rationale:**
+- HSTS og CSP er de to mest impactfulde headers for en offentlig webapp
+- Secure-flag på cookies er lav indsats, høj sikkerhedsgevinst
+- Rettelserne foretages i Nginx så de gælder uafhængigt af applikationslaget
+
+**Fordele:**
+- Eliminerer de tre kritiske fund og forbedrer Observatory-score markant
+- Nginx-niveau rettelser kræver ingen kodeændringer i Sinatra
+- HSTS sikrer at fremtidige besøg altid bruger HTTPS
+
+**Ulemper:**
+- CSP kan bryde ekstern CSS/JS hvis den sættes for restriktivt
+- HSTS er svær at rulle tilbage når den først er sat (browsere husker den)
+
+**Retrospektiv:** (Opdateres løbende)
+- Sikkerheds-headers er en hurtig gevinst men kræver test — især CSP kan have utilsigtede konsekvenser for applikationens 
+funktionalitet
+
+------
+
 ## 
 
 ### Context

--- a/docs/choices-and-challenges/Choices and Challenges.md
+++ b/docs/choices-and-challenges/Choices and Challenges.md
@@ -1301,23 +1301,21 @@ Desuden:
 
 ------
 
-## Sikr systemet
+## Sikr systemet med snyk
 
 ### Context
 
 ### Challenge
 -
 
-**Overvejede patterns:**
-- snyk fravalgt pga. flg.: 
-  - gratis version har begrænsninger og kræver ekstern konto
-  - bundler-audit og brakeman er allerede integreret og dækker hhv. dependency og code security
-  - snyk ville tilføje et dashboard, alerts og PR-kommentarer, hvor bundler-audit rapporterer i terminal og lader 
-    pipeline fejle ved sårbarheder
-
 ### Choice
 **Beslutning:**
-
+- snyk fravalgt pga. flg.:
+    - gratis version har begrænsninger og kræver ekstern konto
+    - bundler-audit og brakeman er allerede integreret og dækker hhv. dependency og code security
+    - snyk ville tilføje et dashboard, alerts og PR-kommentarer, hvor bundler-audit rapporterer i terminal og lader
+      pipeline fejle ved sårbarheder
+  
 **Implementering:**
 
 ```markdown
@@ -1389,6 +1387,56 @@ Eksisterende og velfungerende:
 **Retrospektiv:** (Opdateres løbende)
 - Sikkerheds-headers er en hurtig gevinst men kræver test — især CSP kan have utilsigtede konsekvenser for applikationens 
 funktionalitet
+
+------
+
+## Sikr serveren med Lynis
+
+### Context
+Produktionsserveren (whoknows-vm, Ubuntu 22.04 LTS på Azure) blev auditeret med Lynis som del af sikkerhedsreviewet.
+Hardening Index: 64/100.
+
+### Challenge
+- Lynis identificerede én kritisk warning og flere SSH-relaterede sårbarheder med standardindstillinger der er for løse 
+til en produktionsserver.
+
+### Choice
+**Beslutning:** Adressér den kritiske warning og SSH-hardening. Acceptér øvrige suggestions som kendte begrænsninger 
+på en cloud-VM.
+
+**Implementering:**
+
+```markdown
+Kritisk warning:
+- KRNL-5830: Serveren genstartet efter ventende kernel-opdatering
+
+SSH-hardening (/etc/ssh/sshd_config):
+- LogLevel: INFO → VERBOSE
+- MaxAuthTries: 6 → 3
+- MaxSessions: 10 → 2
+- AllowAgentForwarding: yes → no
+- AllowTcpForwarding: yes → no
+- X11Forwarding: yes → no
+- Compression: yes → no
+- ClientAliveCountMax: 3 → 2
+
+Fail2ban:
+- DEB-0880: jail.conf kopieret til jail.local
+
+Accepteret risiko:
+- BOOT-5122: GRUB password — ikke relevant på cloud-VM (ingen fysisk adgang)
+- FILE-6310: Separate partitioner — kræver VM-opsætning
+- USB-1000: USB-drivere — ikke relevant på cloud-VM
+- HTTP-6710: Lynis detekterer ikke vores HTTPS korrekt
+```
+
+**Rationale:**
+- SSH er den primære adgangsvej til serveren — hardening her har størst sikkerhedsgevinst
+- Accepteret risiko dokumenteres eksplicit frem for at ignoreres
+
+**Læring:**
+- Lynis skelner ikke mellem cloud-VM og fysisk server — mange suggestions er irrelevante i cloud-kontekst og kræver 
+aktiv stillingtagen frem for blind implementering
 
 ------
 

--- a/docs/choices-and-challenges/Choices and Challenges.md
+++ b/docs/choices-and-challenges/Choices and Challenges.md
@@ -1301,7 +1301,47 @@ Desuden:
 
 ------
 
-##
+## Sikr systemet
+
+### Context
+
+### Challenge
+-
+
+**Overvejede patterns:**
+- snyk fravalgt pga. flg.: 
+  - gratis version har begrænsninger og kræver ekstern konto
+  - bundler-audit og brakeman er allerede integreret og dækker hhv. dependency og code security
+  - snyk ville tilføje et dashboard, alerts og PR-kommentarer, hvor bundler-audit rapporterer i terminal og lader 
+    pipeline fejle ved sårbarheder
+
+### Choice
+**Beslutning:**
+
+**Implementering:**
+
+```markdown
+
+```
+
+**Rationale:**
+-
+
+**Fordele:**
+-
+
+**Ulemper:**
+-
+
+**Retrospektiv:** (Opdateres løbende)
+-
+
+**Læring:**
+-
+
+------
+
+## 
 
 ### Context
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -23,6 +23,9 @@ http {
         # Limit referrer information sent to external sites
             add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
+        # CSP — only allow resources from own origin
+        add_header Content-Security-Policy "default-src 'self'" always;
+
         # Proxy requests to Sinatra app
         location / {
             proxy_pass http://web:4567;

--- a/nginx.conf
+++ b/nginx.conf
@@ -20,6 +20,9 @@ http {
         # HSTS — tell browsers to always use HTTPS for the next year
             add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
+        # Limit referrer information sent to external sites
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
         # Proxy requests to Sinatra app
         location / {
             proxy_pass http://web:4567;

--- a/nginx.conf
+++ b/nginx.conf
@@ -17,6 +17,9 @@ http {
         ssl_certificate /etc/letsencrypt/live/monkknows.dk/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/monkknows.dk/privkey.pem;
 
+        # HSTS — tell browsers to always use HTTPS for the next year
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
         # Proxy requests to Sinatra app
         location / {
             proxy_pass http://web:4567;

--- a/ruby-sinatra/app.rb
+++ b/ruby-sinatra/app.rb
@@ -33,7 +33,7 @@ class WhoknowsApp < Sinatra::Base
   # To prevent CSRF attacks by not sending cookies on cross-site requests
   set :sessions,
       same_site: :strict,
-      secure: ENV['RACK_ENV'] == 'production',
+      secure: ENV['RACK_ENV'] == 'production', # Only send cookies over HTTPS in production
       httponly: true # JS cannot read the cookie. Protects from XSS attacks stealing the session cookie
 
   # Test - no DB needed - http://localhost:4567/hello

--- a/ruby-sinatra/app.rb
+++ b/ruby-sinatra/app.rb
@@ -23,8 +23,7 @@ class WhoknowsApp < Sinatra::Base
   set :views, File.expand_path('views', __dir__)
   set :bind, '0.0.0.0'
 
-  # Session configuration (nødvendig for login/logout)
-  enable :sessions
+  # Session configuration (needed for login/logout)
   set :session_secret,
       if ENV['RACK_ENV'] == 'production'
         ENV.fetch('SESSION_SECRET') { raise 'SESSION_SECRET must be set in production' }
@@ -32,7 +31,10 @@ class WhoknowsApp < Sinatra::Base
         ENV.fetch('SESSION_SECRET') { 'x' * 64 }
       end
   # To prevent CSRF attacks by not sending cookies on cross-site requests
-  set :sessions, same_site: :strict
+  set :sessions,
+      same_site: :strict,
+      secure: ENV['RACK_ENV'] == 'production',
+      httponly: true # JS cannot read the cookie. Protects from XSS attacks stealing the session cookie
 
   # Test - no DB needed - http://localhost:4567/hello
   get '/hello' do


### PR DESCRIPTION
## Description
Replaces the SHA pin of Docker login because of a failing cd pipeline.

## Related Issue
Closes #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [ ] Documentation
- [ ] DevOps / Infrastructure
- [ ] Chore

## Changes Made
- 

## How to Test
1. 
2. 
3. 

## Checklist
- [ ] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [ ] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)
