### PR TITLE
Updated SHA pin of Docker Scout in cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -80,7 +80,7 @@ jobs:
 
       # Docker Scout — informational scan (reports findings, does not block pipeline)
       - name: Docker Scout CVE scan
-        uses: docker/scout-action@f8c776824083494ab0d56b8105ba2ca85c86e4de
+        uses: docker/scout-action@bacf462e8d090c09660de30a6ccc718035f961e3
         with:
           command: cves
           image: ghcr.io/${{ env.DOCKER_GITHUB_USERNAME }}/monkknows:latest


### PR DESCRIPTION
## Description
Updated SHA pin of Docker Scout in cd.yml because of failing cd-pipeline


## Related Issue
Closes #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [ ] Documentation
- [ ] DevOps / Infrastructure
- [ ] Chore

## Changes Made
- 

## How to Test
1. 
2. 
3. 

## Checklist
- [ ] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [ ] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)
