### PR TITLE
Bug docker scout

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -80,7 +80,7 @@ jobs:
 
       # Docker Scout — informational scan (reports findings, does not block pipeline)
       - name: Docker Scout CVE scan
-        uses: docker/scout-action@bacf462e8d090c09660de30a6ccc718035f961e3
+        uses: docker/scout-action@f8c776824083494ab0d56b8105ba2ca85c86e4de
         with:
           command: cves
           image: ghcr.io/${{ env.DOCKER_GITHUB_USERNAME }}/monkknows:latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,19 +77,6 @@ jobs:
           write-comment: false
           summary: true
 
-
-      # Docker Scout — informational scan (reports findings, does not block pipeline)
-      - name: Docker Scout CVE scan
-        uses: docker/scout-action@f8c776824083494ab0d56b8105ba2ca85c86e4de
-        with:
-          command: cves
-          image: ghcr.io/${{ env.DOCKER_GITHUB_USERNAME }}/monkknows:latest
-          only-severities: critical,high
-          exit-code: false
-          write-comment: false
-          summary: true
-
-
       # Push the same scanned image — no rebuild
       - name: Push Docker image to GHCR
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,17 +66,6 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: 'true'
 
-      # Docker Scout — informational scan (reports findings, does not block pipeline)
-      - name: Docker Scout CVE scan
-        uses: docker/scout-action@f8c776824083494ab0d56b8105ba2ca85c86e4de
-        with:
-          command: cves
-          image: ghcr.io/${{ env.DOCKER_GITHUB_USERNAME }}/monkknows:latest
-          only-severities: critical,high
-          exit-code: false
-          write-comment: false
-          summary: true
-
       # Push the same scanned image — no rebuild
       - name: Push Docker image to GHCR
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -80,7 +80,7 @@ jobs:
 
       # Docker Scout — informational scan (reports findings, does not block pipeline)
       - name: Docker Scout CVE scan
-        uses: docker/scout-action@f8c776824083494ab0d56b8105ba2ca85c86e4de
+        uses: docker/scout-action@bacf462e8d090c09660de30a6ccc718035f961e3
         with:
           command: cves
           image: ghcr.io/${{ env.DOCKER_GITHUB_USERNAME }}/monkknows:latest

--- a/docs/choices-and-challenges/Choices and Challenges.md
+++ b/docs/choices-and-challenges/Choices and Challenges.md
@@ -1326,6 +1326,10 @@ genbruges
 - To specialiserede Ruby-værktøjer foretrækkes frem for Snyk
   Docker Scout og Trivy supplerer hinanden da de slår op i forskellige CVE-databaser
 
+### Læring
+- Docker Scout kunne ikke integreres med GitHub Actions uden brugerkonto hos Docker Hub, derfor
+blev det fravalgt i CI, da Trivy dækker samme behov uden ekstern afhængighed
+
 ------
 
 ## Observatory resultater 


### PR DESCRIPTION
## Description
Removed Docker Scout from our pipeline because it required a DockerHub account


## Related Issue
Closes #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [ ] Documentation
- [ ] DevOps / Infrastructure
- [ ] Chore

## Changes Made
- 

## How to Test
1. 
2. 
3. 

## Checklist
- [ ] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [ ] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)
