### PR TITLE
Implement SQLite FTS5 for faster, relevance-ranked search

### DIFF
--- a/ruby-sinatra/app.rb
+++ b/ruby-sinatra/app.rb
@@ -89,8 +89,10 @@ class WhoknowsApp < Sinatra::Base
     @language = params[:language] || 'en'
 
     @results = if @q && !@q.strip.empty?
-                 Page.where(language: @language)
-                     .where('content LIKE ?', "%#{@q}%")
+                 Page.joins('INNER JOIN pages_fts ON pages.rowid = pages_fts.rowid')
+                     .where(language: @language)
+                     .where('pages_fts MATCH ?', @q)
+                     .order(Arel.sql('pages_fts.rank'))
                else
                  []
                end
@@ -144,8 +146,10 @@ class WhoknowsApp < Sinatra::Base
       }.to_json
 
     else
-      search_results = Page.where(language: language)
-                           .where('content LIKE ?', "%#{q}%")
+      search_results = Page.joins('INNER JOIN pages_fts ON pages.rowid = pages_fts.rowid')
+                           .where(language: language)
+                           .where('pages_fts MATCH ?', q)
+                           .order(Arel.sql('pages_fts.rank'))
                            .as_json
 
       status 200

--- a/ruby-sinatra/db/migrate_to_fts5.rb
+++ b/ruby-sinatra/db/migrate_to_fts5.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Migration script: creates FTS5 virtual table for full-text search
+# Run once: ruby db/migrate_to_fts5.rb
+#
+# Creates a virtual FTS5 table mirroring pages, plus triggers to keep it in sync.
+# After migration, search queries use FTS5 ranking instead of LIKE.
+
+require_relative '../config/environment'
+
+connection = ActiveRecord::Base.connection
+
+# Create FTS5 virtual table with content synced from pages
+connection.execute(<<-SQL)
+  CREATE VIRTUAL TABLE IF NOT EXISTS pages_fts USING fts5(
+    title,
+    content,
+    content='pages',
+    content_rowid='rowid'
+  );
+SQL
+
+# Populate FTS5 table with existing data
+connection.execute(<<-SQL)
+  INSERT INTO pages_fts(rowid, title, content)
+  SELECT rowid, title, content FROM pages;
+SQL
+
+# Trigger: keep FTS5 in sync on INSERT
+connection.execute(<<-SQL)
+  CREATE TRIGGER IF NOT EXISTS pages_ai AFTER INSERT ON pages BEGIN
+    INSERT INTO pages_fts(rowid, title, content)
+    VALUES (new.rowid, new.title, new.content);
+  END;
+SQL
+
+# Trigger: keep FTS5 in sync on DELETE
+connection.execute(<<-SQL)
+  CREATE TRIGGER IF NOT EXISTS pages_ad AFTER DELETE ON pages BEGIN
+    INSERT INTO pages_fts(pages_fts, rowid, title, content)
+    VALUES('delete', old.rowid, old.title, old.content);
+  END;
+SQL
+
+# Trigger: keep FTS5 in sync on UPDATE
+connection.execute(<<-SQL)
+  CREATE TRIGGER IF NOT EXISTS pages_au AFTER UPDATE ON pages BEGIN
+    INSERT INTO pages_fts(pages_fts, rowid, title, content)
+    VALUES('delete', old.rowid, old.title, old.content);
+    INSERT INTO pages_fts(rowid, title, content)
+    VALUES (new.rowid, new.title, new.content);
+  END;
+SQL
+
+row_count = connection.execute('SELECT count(*) as cnt FROM pages_fts').first['cnt']
+puts "Migration complete: FTS5 table created with #{row_count} rows"


### PR DESCRIPTION
## Summary
- Creates FTS5 virtual table mirroring `pages` with automatic sync triggers
- Replaces `LIKE` search with FTS5 `MATCH` for both HTML and API endpoints
- Results are now ranked by relevance instead of arbitrary order

## Post-deploy
Run on server: `docker exec -it <container> ruby db/migrate_to_fts5.rb`

## Test plan
- [x] Migration populates FTS5 table with all 51 existing pages
- [x] Single-word search returns relevant results
- [x] Multi-word search works and ranks by relevance
- [x] Empty query returns 422 as before
- [x] Both `/` and `/api/search` endpoints work

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)