### PR TITLE
feat: switch from SQLite to PostgreSQL adapter

### DIFF
--- a/ruby-sinatra/Dockerfile
+++ b/ruby-sinatra/Dockerfile
@@ -7,7 +7,7 @@ ARG BUNDLE_WITHOUT="development test"
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         build-essential \
-        libsqlite3-dev \
+        libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -29,7 +29,7 @@ FROM ruby:3.2-slim
 RUN apt-get update -qq && \
     apt-get upgrade -y --no-install-recommends && \
     apt-get install -y --no-install-recommends \
-        libsqlite3-0 \
+        libpq5 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/ruby-sinatra/Gemfile
+++ b/ruby-sinatra/Gemfile
@@ -13,7 +13,8 @@ gem 'rackup'
 gem 'rake' # Runs the db:migrate command
 gem 'sinatra', '~> 4.0'
 gem 'sinatra-activerecord'
-gem 'sqlite3', '~> 1.6'
+gem 'pg', '~> 1.5' # PostgreSQL adapter for production and development
+gem 'sqlite3', '~> 1.6', group: :test # Only needed for in-memory test database
 
 group :test do
   gem 'committee' # For testing API responses against OpenAPI specs

--- a/ruby-sinatra/Gemfile.lock
+++ b/ruby-sinatra/Gemfile.lock
@@ -84,6 +84,8 @@ GEM
     parser (3.3.10.2)
       ast (~> 2.4.1)
       racc
+    pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-linux)
     prism (1.9.0)
     pry (0.16.0)
       coderay (~> 1.1)
@@ -179,6 +181,7 @@ DEPENDENCIES
   guard
   guard-shell
   ostruct
+  pg (~> 1.5)
   puma
   rack-test
   rackup

--- a/ruby-sinatra/config/database.yml
+++ b/ruby-sinatra/config/database.yml
@@ -13,10 +13,10 @@ development:
 # Production (VM2 PostgreSQL server)
 production:
   adapter: postgresql
-  host: <%= ENV['DB_HOST'] %>
-  database: <%= ENV.fetch('DB_NAME', 'monkknows') %>
-  username: <%= ENV['DB_USER'] %>
-  password: <%= ENV['DB_PASSWORD'] %>
+  host: <%= ENV.fetch('DB_HOST') { raise 'DB_HOST must be set in production' } %>
+  database: <%= ENV.fetch('DB_NAME') { raise 'DB_NAME must be set in production' } %>
+  username: <%= ENV.fetch('DB_USER') { raise 'DB_USER must be set in production' } %>
+  password: <%= ENV.fetch('DB_PASSWORD') { raise 'DB_PASSWORD must be set in production' } %>
   pool: 5
 
 # In-memory SQLite for fast unit tests
@@ -30,7 +30,7 @@ test:
 e2e:
   adapter: postgresql
   host: <%= ENV.fetch('DB_HOST', 'db') %>
-  database: <%= ENV.fetch('DB_NAME', 'monkknows_e2e') %>
+  database: <%= ENV.fetch('DB_NAME_E2E', 'monkknows_e2e') %>
   username: <%= ENV.fetch('DB_USER', 'monkknows') %>
   password: <%= ENV.fetch('DB_PASSWORD', 'dev_password') %>
   pool: 5

--- a/ruby-sinatra/config/database.yml
+++ b/ruby-sinatra/config/database.yml
@@ -1,33 +1,36 @@
-# DB config : skal pege til ../whoknows.db
 # Database connection settings
+# PostgreSQL for development and production, SQLite for tests
 
-# Kan udkommenteres når db skal bruges
-#development:
-  #adapter: sqlite3
-  #database: ../whoknows.db
-
-# For local development and Docker-dev
+# Local development via Docker (docker-compose.dev.yml provides the 'db' service)
 development:
-  adapter: sqlite3
-  database: <%= ENV.fetch('DATABASE_PATH', '../whoknows.db') %>
+  adapter: postgresql
+  host: <%= ENV.fetch('DB_HOST', 'db') %>
+  database: <%= ENV.fetch('DB_NAME', 'monkknows_dev') %>
+  username: <%= ENV.fetch('DB_USER', 'monkknows') %>
+  password: <%= ENV.fetch('DB_PASSWORD', 'dev_password') %>
   pool: 5
-  timeout: 5000
 
-# For production (Docker)
+# Production (VM2 PostgreSQL server)
 production:
-  adapter: sqlite3
-  database: <%= ENV.fetch('DATABASE_PATH', '../whoknows.db') %>
+  adapter: postgresql
+  host: <%= ENV['DB_HOST'] %>
+  database: <%= ENV.fetch('DB_NAME', 'monkknows') %>
+  username: <%= ENV['DB_USER'] %>
+  password: <%= ENV['DB_PASSWORD'] %>
   pool: 5
-  timeout: 5000
 
+# In-memory SQLite for fast unit tests
 test:
   adapter: sqlite3
   database: ":memory:"
   pool: 5
   timeout: 5000
 
+# E2E tests use PostgreSQL to match production
 e2e:
-  adapter: sqlite3
-  database: <%= ENV.fetch('DATABASE_PATH', '../whoknows.db') %>
+  adapter: postgresql
+  host: <%= ENV.fetch('DB_HOST', 'db') %>
+  database: <%= ENV.fetch('DB_NAME', 'monkknows_e2e') %>
+  username: <%= ENV.fetch('DB_USER', 'monkknows') %>
+  password: <%= ENV.fetch('DB_PASSWORD', 'dev_password') %>
   pool: 5
-  timeout: 5000


### PR DESCRIPTION
## Summary
- Add `pg` gem, move `sqlite3` to test-only group
- Update `database.yml`: dev/prod/e2e use PostgreSQL, test stays SQLite in-memory
- Update Dockerfile: `libpq-dev`/`libpq5` replaces `libsqlite3`

## Part of
Sub-branch for #203 — task #3 in migration spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated database configuration from SQLite to PostgreSQL for development, production, and end-to-end testing environments.
  * Updated database library dependencies to support PostgreSQL connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->