### PR TITLE
fix: pre-commit hook double-prefixes ruby-sinatra/ path

### DIFF
--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -25,7 +25,7 @@ if docker compose -f docker-compose.dev.yml ps --status running web 2>/dev/null 
   echo "$CONTAINER_FILES" | xargs docker compose -f docker-compose.dev.yml exec -T web bundle exec rubocop --force-exclusion
   RESULT=$?
 elif cd ruby-sinatra 2>/dev/null; then
-  echo "$STAGED_RB" | xargs bundle exec rubocop --force-exclusion
+  echo "$CONTAINER_FILES" | xargs bundle exec rubocop --force-exclusion
   RESULT=$?
 else
   echo "⚠️  Skipping RuboCop — Docker not running and rubocop not installed locally"


### PR DESCRIPTION
## Summary
- Fix bug where local RuboCop fallback passed `ruby-sinatra/app.rb` after `cd ruby-sinatra`, causing "No such file" errors
- Uses `CONTAINER_FILES` (already stripped of prefix) consistently in both Docker and local paths

## Test plan
- [ ] Run `bash scripts/install-hooks.sh` to reinstall hook
- [ ] Stage a `.rb` file and commit without Docker running — should pass without path errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)