### PR TITLE
Added query to after do block for search logger, to log for what the …

### DIFF
--- a/ruby-sinatra/app.rb
+++ b/ruby-sinatra/app.rb
@@ -83,7 +83,8 @@ class WhoknowsApp < Sinatra::Base
       status: response.status,
       ip: request.ip,
       user: session[:user_id] ? Digest::SHA256.hexdigest(session[:user_id].to_s)[0..7] : nil,
-      duration_ms: ((Time.now - request.env['sinatra.route_start_time']) * 1000).round(2)
+      duration_ms: ((Time.now - request.env['sinatra.route_start_time']) * 1000).round(2),
+      query: (params[:q].strip if params[:q] && !params[:q].strip.empty?)
     }.compact
     logger.info(log_data.to_json)
   end


### PR DESCRIPTION
…user is searching for

## Description
Adds query parameter in search logger in app.rb to find out what the user is searching for

## Related Issue
Part of #204

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [ ] Documentation
- [x] DevOps / Infrastructure
- [ ] Chore

## Changes Made
- Added ´query: (params[:q].strip if params[:q] && !params[:q].strip.empty?)´
to
´  after do
    log_data = {
      timestamp: Time.now.utc.iso8601,
      method: request.request_method,
      path: request.path_info,
      status: response.status,
      ip: request.ip,
      user: session[:user_id] ? Digest::SHA256.hexdigest(session[:user_id].to_s)[0..7] : nil,
      duration_ms: ((Time.now - request.env['sinatra.route_start_time']) * 1000).round(2),
      query: (params[:q].strip if params[:q] && !params[:q].strip.empty?)
    }.compact
    logger.info(log_data.to_json)
  end´

## How to Test
1. ssh into server and run command to see the top 10 search queries:
´docker logs <container> 2>&1 \
  | grep '"query"' \
  | grep -oP '"query":"\K[^"]+' \
  | sort | uniq -c | sort -rn | head 10´ 

## Checklist
- [ ] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [ ] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)
