### PR TITLE
feat: add search metrics and clean up dashboard (#240)

### DIFF
--- a/docs/choices-and-challenges/Choices and Challenges.md
+++ b/docs/choices-and-challenges/Choices and Challenges.md
@@ -2099,7 +2099,33 @@ CodeRabbit anbefalede at binde Grafana til `127.0.0.1` (kun tilgængelig via SSH
 
 - Prometheus scraper over offentligt internet (HTTPS) i stedet for internt netværk — højere latency
 - Grafana er eksponeret på offentlig IP (bevidst valg, se ovenfor)
-- Custom metrics (search-telemetri) afhænger af Sofies logging-PR (#246)
+- ~~Custom metrics (search-telemetri) afhænger af Sofies logging-PR (#246)~~ — tilføjet i fase 2 (se nedenfor)
+
+### Fase 2: Søge-metrics og dashboard-opdatering (21/4-2026)
+
+Efter merge af Sofies logging-PR (#246) tilføjede vi søge-specifikke Prometheus metrics:
+
+| Metric | Type | Hvorfor |
+|---|---|---|
+| `app_searches_total` | Counter | Hvor mange søgninger kører over tid — er søgefunktionen brugt? |
+| `app_search_zero_results_total` | Counter | Hvor ofte søger brugere på noget vi ikke har indhold for — input til crawling-strategi |
+
+**Dashboard-opdatering:**
+- Tilføjet stat-panels for Total Searches og Zero-Result Searches i toppen
+- Tilføjet Search Rate timeseries (searches/s + zero results/s over tid)
+- Filtreret "Request Rate per Endpoint" til kun app-routes (whitelist) — fjerner støj fra bot-scanners
+- Tilføjet separat "Bot/Scanner Traffic" panel der viser alt der IKKE matcher app-routes
+
+**Bevidst valg: Whitelist vs blacklist for endpoint-filtrering**
+
+Bot-scannere rammer hundredvis af stier (`.env`, `.aws/credentials`, `/wp-admin`, osv.). Vi valgte whitelist-tilgang (kun vise kendte app-routes) frem for blacklist (ekskludere kendte scanner-stier), fordi:
+- Nye scanner-stier dukker konstant op — blacklist kræver vedligeholdelse
+- Whitelist er stabil — ændres kun når vi tilføjer nye routes
+- Bot-trafikken er stadig synlig i sit eget panel, så vi mister ikke indsigten
+
+**Fund: Bot-scanner aktivitet opdaget via monitoring**
+
+Dashboardet afslørede at vores server konstant scannes af automatiserede bots der leder efter eksponerede credentials (`.env`, `.aws/config`, `.git/config` osv.). Dette er et direkte eksempel på Anders' pointe: "It's an impressive sign if your setup makes you realize something that helps you improve your system."
 
 ### Læring
 
@@ -2107,6 +2133,8 @@ CodeRabbit anbefalede at binde Grafana til `127.0.0.1` (kun tilgængelig via SSH
 - Prometheus label-navne varierer mellem gem-versioner — tjek altid `/metrics` output direkte
 - `rsync --delete` er idempotent; `scp -r` er det ikke — vigtigt for CD pipelines
 - Monitoring og applikation bør være på separate servere — hvis appen crasher, mister du ellers også dine metrics
+- Zero-result rate er direkte input til crawling-strategi — hvis brugere søger på emner vi ikke har, ved vi hvad vi skal scrape
+- Whitelist-filtrering af endpoints er mere robust end blacklist for dashboards med offentligt eksponerede servere
 
 ------
 

--- a/monitoring/grafana/dashboards/monkknows.json
+++ b/monitoring/grafana/dashboards/monkknows.json
@@ -11,13 +11,64 @@
   },
   "panels": [
     {
+      "id": 5,
+      "title": "Total Registered Users",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "app_users_total{job=\"monkknows\"}",
+          "legendFormat": "Users"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Total Searches",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "targets": [
+        {
+          "expr": "app_searches_total{job=\"monkknows\"}",
+          "legendFormat": "Searches"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Zero-Result Searches",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "app_search_zero_results_total{job=\"monkknows\"}",
+          "legendFormat": "No results"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
+    },
+    {
       "id": 1,
-      "title": "Request Rate per Endpoint",
+      "title": "Request Rate per Endpoint (app routes)",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
       "targets": [
         {
-          "expr": "sum(rate(http_server_requests_total{job=\"monkknows\"}[5m])) by (path)",
+          "expr": "sum(rate(http_server_requests_total{job=\"monkknows\",path=~\"/|/api/.*|/health|/hello|/login|/register|/weather|/logout|/metrics\"}[5m])) by (path)",
           "legendFormat": "{{path}}"
         }
       ],
@@ -49,10 +100,31 @@
       }
     },
     {
+      "id": 8,
+      "title": "Search Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "targets": [
+        {
+          "expr": "rate(app_searches_total{job=\"monkknows\"}[5m])",
+          "legendFormat": "Searches/s"
+        },
+        {
+          "expr": "rate(app_search_zero_results_total{job=\"monkknows\"}[5m])",
+          "legendFormat": "Zero results/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        }
+      }
+    },
+    {
       "id": 3,
       "title": "Error Rate: 4xx vs 5xx",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
       "targets": [
         {
           "expr": "sum(rate(http_server_requests_total{job=\"monkknows\",code=~\"4..\"}[5m]))",
@@ -73,7 +145,7 @@
       "id": 4,
       "title": "Request Latency (p50, p95)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
       "targets": [
         {
           "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket{job=\"monkknows\"}[5m])) by (le))",
@@ -91,19 +163,19 @@
       }
     },
     {
-      "id": 5,
-      "title": "Total Registered Users",
-      "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 9,
+      "title": "Bot/Scanner Traffic (non-app routes)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
       "targets": [
         {
-          "expr": "app_users_total{job=\"monkknows\"}",
-          "legendFormat": "Users"
+          "expr": "sum(rate(http_server_requests_total{job=\"monkknows\",path!~\"/|/api/.*|/health|/hello|/login|/register|/weather|/logout|/metrics\"}[5m])) by (path)",
+          "legendFormat": "{{path}}"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short"
+          "unit": "reqps"
         }
       }
     }

--- a/ruby-sinatra/app.rb
+++ b/ruby-sinatra/app.rb
@@ -34,6 +34,16 @@ class WhoknowsApp < Sinatra::Base
     docstring: 'Total number of registered users',
     labels: []
   )
+  SEARCHES_TOTAL = PROMETHEUS.counter(
+    :app_searches_total,
+    docstring: 'Total number of search queries',
+    labels: []
+  )
+  SEARCH_ZERO_RESULTS = PROMETHEUS.counter(
+    :app_search_zero_results_total,
+    docstring: 'Total number of searches that returned no results',
+    labels: []
+  )
 
   # Update user count gauge every 60 seconds in a background thread
   unless ENV['RACK_ENV'] == 'test'
@@ -151,7 +161,10 @@ class WhoknowsApp < Sinatra::Base
     @language = params[:language] || 'en'
 
     @results = if @q && !@q.strip.empty?
-                 Page.search(@q, language: @language)
+                 SEARCHES_TOTAL.increment
+                 results = Page.search(@q, language: @language)
+                 SEARCH_ZERO_RESULTS.increment if results.empty?
+                 results
                else
                  []
                end
@@ -207,11 +220,13 @@ class WhoknowsApp < Sinatra::Base
       }.to_json
 
     else
-      search_results = Page.search(q, language: language).as_json(except: :tsv)
+      SEARCHES_TOTAL.increment
+      search_results = Page.search(q, language: language)
+      SEARCH_ZERO_RESULTS.increment if search_results.empty?
 
       status 200
       {
-        data: search_results
+        data: search_results.as_json(except: :tsv)
       }.to_json
     end
   end


### PR DESCRIPTION
## Description
Adds search-specific Prometheus metrics and updates the Grafana dashboard.

Part of issue #240 (fase 2 — now that #246 is merged)

## Related Issue
Closes #240

## Type of Change
- [x] New feature
- [x] DevOps / Infrastructure

## Changes Made

### Search metrics (app.rb)
- `app_searches_total` counter — incremented on every search query
- `app_search_zero_results_total` counter — incremented when search returns no results

### Dashboard update (monkknows.json)
- Added stat panels: Total Searches, Zero-Result Searches (top row)
- Added Search Rate timeseries panel
- Filtered Request Rate to app routes only (whitelist)
- Added Bot/Scanner Traffic panel showing non-app route requests

### Documentation
- Documented fase 2 choices in Choices & Challenges

## Checklist
- [x] Tested locally
- [x] No hardcoded secrets or credentials

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search metrics monitoring now available, tracking total searches and zero-result searches in real-time.

* **Chores**
  * Dashboard updated with new search activity visualization panels and improved filtering to distinguish app traffic from bot/scanner activity.

* **Documentation**
  * Enhanced monitoring documentation with new search telemetry details and dashboard strategy information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->