### PR TITLE
fix: session cookies broken behind nginx SSL termination

### DIFF
--- a/docs/choices-and-challenges/Choices and Challenges.md
+++ b/docs/choices-and-challenges/Choices and Challenges.md
@@ -2349,30 +2349,41 @@ Sofies logging-system bruger en separat SQLite-database via `LoggingBase`. Ved c
 - Smoke tests i CD pipelinen fangede fejlen — uden dem ville vi først opdage det manuelt
 
 
+## Session-cookies virker ikke bag nginx SSL-terminering
+
+### Context
+
+Anders' simulator rapporterede daglige `e2e_error:can_log_in`-fejl: simulatoren kunne logge ind (200 OK fra `/api/login`) men fandt aldrig `#nav-logout`-linket på `/` efterfølgende — dvs. sessionen gik tabt mellem login-kaldet og næste sideload.
+
 ### Challenge
 
+Login-endpointet returnerede 200 og autentificering virkede korrekt — men der var ingen `Set-Cookie`-header i svaret. Det betød at browseren/simulatoren aldrig modtog en session-cookie, og at alle efterfølgende requests var anonyme.
+
+Rodårsagen: Nginx terminerer SSL og forwarter requests til Sinatra over intern HTTP (`proxy_pass http://web:4567`). Rack's session-middleware (`Rack::Session::Cookie`) har `secure: true` i produktion, og **Rack sætter ikke en secure session-cookie hvis den ikke kan se at forbindelsen er HTTPS** — den tjekker `request.ssl?`, som checker `HTTP_X_FORWARDED_PROTO`. Fordi nginx ikke forwardede denne header, troede Rack at forbindelsen var plain HTTP og droppede cookien lydløst.
+
+Dette har sandsynligvis været brudt siden HTTPS blev sat op, og forklarer alle simulator-login-fejl siden da.
 
 ### Choice
 
-**Beslutning:**
+Tilføjet `proxy_set_header X-Forwarded-Proto $scheme;` til `location /`-blokken i `nginx.conf`. Med denne header sætter Rack `rack.url_scheme = 'https'`, `request.ssl?` returnerer true, og session-cookien skrives korrekt.
 
-**Implementering:**
+**Bevidst fravalg:** Vi validerer ikke at `X-Forwarded-Proto` kun kan komme fra en betroet proxy (f.eks. via IP-whitelist). I vores setup er Sinatra-containeren kun tilgængelig via Docker-netværket (ikke eksponeret udadtil), så spoofing-risikoen er minimal.
 
-```
+### Fordele
 
-```
+- Session-cookies sættes nu korrekt — login virker for alle brugere og simulatoren
+- En-linje fix i nginx.conf, ingen app-kode-ændringer nødvendige
+- Standard løsning på et velkendt reverse-proxy + SSL-terminering problem
 
-**Rationale:**
+### Ulemper
 
+- `X-Forwarded-Proto` er ikke cryptografisk verificeret — men intern Docker-netværksisolering mitigerer risikoen
 
+### Læring
 
-**Fordele:**
-
-
-
-**Ulemper:**
-
--
+- `secure: true` på Rack session-cookies er ikke kun et browser-hint — Rack sætter slet ikke cookien hvis den ikke ser HTTPS, selvom autentificeringen ellers lykkes
+- SSL-terminerende reverse proxies skal altid forwarde `X-Forwarded-Proto` til backenden, ellers er sikre cookies ubrugelige
+- Fejlen var usynlig fra app-laget (200 OK, ingen exception) — den krævede inspektion af response-headers for at afsløre at `Set-Cookie` manglede
 
 **Læring:**
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -41,6 +41,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
 }


### PR DESCRIPTION
## Description
Login virker (200 OK) men sessionen gemmes aldrig — `#nav-logout` vises ikke efter login, og simulatoren fejler med `e2e_error:can_log_in` på alle kørsler.

**Rodårsag:** Nginx terminerer SSL og forwarter til Sinatra over intern HTTP. Rack's `Rack::Session::Cookie` med `secure: true` sætter ikke session-cookien når `request.ssl?` returnerer false — og det gør den fordi `HTTP_X_FORWARDED_PROTO` manglede. Rack dropper cookien lydløst; login returnerer 200 men ingen `Set-Cookie`-header.

**Fix:** Én linje i `nginx.conf`:
```
proxy_set_header X-Forwarded-Proto $scheme;
```

## Related Issue
Relateret til simulator-fejl `e2e_error:can_log_in` (daglige fejl siden PostgreSQL-migration)

## Type of Change
- [x] Bug fix

## Changes Made
- Tilføjet `proxy_set_header X-Forwarded-Proto $scheme;` til `location /` i `nginx.conf`
- Dokumenteret i Choices & Challenges

## How to Test
1. Deploy til produktion (CD kører automatisk ved merge til `main`)
2. `curl -s -D - -X POST https://monkknows.dk/api/login -H "Content-Type: application/x-www-form-urlencoded" -d "username=admin&password=password"` — verificer at `Set-Cookie`-headeren nu er til stede
3. Tjek `http://158.158.49.35:8000/logs/errors/nasOps` — `e2e_error:can_log_in`-fejl bør stoppe

## Checklist
- [x] Tested locally (curl mod prod bekræftede manglende Set-Cookie)
- [ ] OpenAPI spec updated (if endpoint changed) — N/A
- [x] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable) — N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session cookie handling in production behind nginx SSL termination, where login requests weren't properly setting session cookies, causing users to appear as anonymous.

* **Documentation**
  * Added documentation explaining the SSL termination session issue, the configuration solution, and trade-offs related to secure cookie handling and reverse-proxy header forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->