### PR TITLE
feat: Test POST /api/register endpoint

### DIFF
--- a/ruby-sinatra/app.rb
+++ b/ruby-sinatra/app.rb
@@ -294,10 +294,8 @@ class WhoknowsApp < Sinatra::Base
       status 200
       { statusCode: 200, message: 'You were successfully registered' }.to_json
     else
-      # .errors.full_messages.first gives the first validation-error
-      # e.g. "You have to enter a username"
       status 422
-      { detail: [{ loc: ['body'], msg: user.errors.full_messages.first, type: 'value_error' }] }.to_json
+      { detail: [{ loc: ['body'], msg: user.errors.first&.message, type: 'value_error' }] }.to_json
     end
   end
 

--- a/ruby-sinatra/spec/integration/app_spec.rb
+++ b/ruby-sinatra/spec/integration/app_spec.rb
@@ -5,14 +5,14 @@ require 'rack/test'
 require 'prometheus/middleware/collector'
 require 'prometheus/middleware/exporter'
 
-## This module provides methods like `get`, `post`, etc.
-# to simulate HTTP requests in tests.
 RSpec.describe 'Whoknows App' do
   include Rack::Test::Methods
 
   def app
-    WhoknowsApp # Tells RSpec which app to test
+    WhoknowsApp
   end
+
+  # ── GET /hello ──────────────────────────────────────────────────────────────
 
   describe 'GET /hello' do
     it 'returns 200 OK' do
@@ -21,33 +21,36 @@ RSpec.describe 'Whoknows App' do
     end
   end
 
-  describe 'Session management' do
-    # Test 1: before-filter sætter @current_user til nil når ingen er logget ind
-    describe 'before filter' do
-      it 'loads without error when no user is in session' do
-        get '/'
-        expect(last_response.status).to eq(200)
-      end
-    end
+  # ── GET / ───────────────────────────────────────────────────────────────────
 
-    # Test 2: login returnerer 422 og sætter ikke session ved forkerte credentials
-    describe 'POST /api/login' do
-      it 'returns 422 with invalid credentials' do
-        post '/api/login', username: 'nobody', password: 'wrong'
-        expect(last_response.status).to eq(422)
-      end
-    end
-
-    # Test 3: logout rydder session og returnerer 200
-    describe 'GET /api/logout' do
-      it 'clears session and returns 200' do
-        get '/api/logout'
-        expect(last_response.status).to eq(200)
-        body = JSON.parse(last_response.body)
-        expect(body['message']).to eq('You were logged out')
-      end
+  describe 'GET /' do
+    it 'returns 200 when no user is in session' do
+      get '/'
+      expect(last_response.status).to eq(200)
     end
   end
+
+  # ── POST /api/login ─────────────────────────────────────────────────────────
+
+  describe 'POST /api/login' do
+    it 'returns 422 with invalid credentials' do
+      post '/api/login', username: 'nobody', password: 'wrong'
+      expect(last_response.status).to eq(422)
+    end
+  end
+
+  # ── GET /api/logout ─────────────────────────────────────────────────────────
+
+  describe 'GET /api/logout' do
+    it 'clears session and returns 200' do
+      get '/api/logout'
+      expect(last_response.status).to eq(200)
+      body = JSON.parse(last_response.body)
+      expect(body['message']).to eq('You were logged out')
+    end
+  end
+
+  # ── POST /api/register ──────────────────────────────────────────────────────
 
   describe 'POST /api/register' do
     let(:valid_params) do
@@ -107,8 +110,9 @@ RSpec.describe 'Whoknows App' do
     end
   end
 
+  # ── GET /metrics ─────────────────────────────────────────────────────────────
+
   describe 'GET /metrics' do
-    # Build the full Rack stack with Prometheus middleware (as in config.ru)
     let(:full_app) do
       Rack::Builder.new do
         use Prometheus::Middleware::Collector

--- a/ruby-sinatra/spec/integration/app_spec.rb
+++ b/ruby-sinatra/spec/integration/app_spec.rb
@@ -49,6 +49,64 @@ RSpec.describe 'Whoknows App' do
     end
   end
 
+  describe 'POST /api/register' do
+    let(:valid_params) do
+      { username: 'testuser', email: 'test@example.com', password: 'secret123', password2: 'secret123' }
+    end
+
+    after(:each) { User.delete_all }
+
+    it 'returns 200 and success message with valid input' do
+      post '/api/register', valid_params
+      expect(last_response.status).to eq(200)
+      body = JSON.parse(last_response.body)
+      expect(body['message']).to eq('You were successfully registered')
+    end
+
+    it 'returns 422 when passwords do not match' do
+      post '/api/register', valid_params.merge(password2: 'wrongpass')
+      expect(last_response.status).to eq(422)
+      body = JSON.parse(last_response.body)
+      expect(body['detail'].first['msg']).to eq('The two passwords do not match')
+    end
+
+    it 'returns 422 when username is blank' do
+      post '/api/register', valid_params.merge(username: '')
+      expect(last_response.status).to eq(422)
+      body = JSON.parse(last_response.body)
+      expect(body['detail'].first['msg']).to include('You have to enter a username')
+    end
+
+    it 'returns 422 when email is blank' do
+      post '/api/register', valid_params.merge(email: '')
+      expect(last_response.status).to eq(422)
+      body = JSON.parse(last_response.body)
+      expect(body['detail'].first['msg']).to include('You have to enter a valid email address')
+    end
+
+    it 'returns 422 when email format is invalid' do
+      post '/api/register', valid_params.merge(email: 'notanemail')
+      expect(last_response.status).to eq(422)
+      body = JSON.parse(last_response.body)
+      expect(body['detail'].first['msg']).to include('You have to enter a valid email address')
+    end
+
+    it 'returns 422 for duplicate username' do
+      post '/api/register', valid_params
+      post '/api/register', valid_params.merge(email: 'other@example.com')
+      expect(last_response.status).to eq(422)
+      body = JSON.parse(last_response.body)
+      expect(body['detail'].first['msg']).to include('The username is already taken')
+    end
+
+    it 'stores password as bcrypt hash, not plaintext' do
+      post '/api/register', valid_params
+      user = User.find_by(username: 'testuser')
+      expect(user.password_digest).to start_with('$2a$')
+      expect(user.password_digest).not_to eq('secret123')
+    end
+  end
+
   describe 'GET /metrics' do
     # Build the full Rack stack with Prometheus middleware (as in config.ru)
     let(:full_app) do

--- a/ruby-sinatra/spec/integration/app_spec.rb
+++ b/ruby-sinatra/spec/integration/app_spec.rb
@@ -77,21 +77,21 @@ RSpec.describe 'Whoknows App' do
       post '/api/register', valid_params.merge(username: '')
       expect(last_response.status).to eq(422)
       body = JSON.parse(last_response.body)
-      expect(body['detail'].first['msg']).to include('You have to enter a username')
+      expect(body['detail'].first['msg']).to eq('You have to enter a username')
     end
 
     it 'returns 422 when email is blank' do
       post '/api/register', valid_params.merge(email: '')
       expect(last_response.status).to eq(422)
       body = JSON.parse(last_response.body)
-      expect(body['detail'].first['msg']).to include('You have to enter a valid email address')
+      expect(body['detail'].first['msg']).to eq('You have to enter a valid email address')
     end
 
     it 'returns 422 when email format is invalid' do
       post '/api/register', valid_params.merge(email: 'notanemail')
       expect(last_response.status).to eq(422)
       body = JSON.parse(last_response.body)
-      expect(body['detail'].first['msg']).to include('You have to enter a valid email address')
+      expect(body['detail'].first['msg']).to eq('You have to enter a valid email address')
     end
 
     it 'returns 422 for duplicate username' do
@@ -99,7 +99,7 @@ RSpec.describe 'Whoknows App' do
       post '/api/register', valid_params.merge(email: 'other@example.com')
       expect(last_response.status).to eq(422)
       body = JSON.parse(last_response.body)
-      expect(body['detail'].first['msg']).to include('The username is already taken')
+      expect(body['detail'].first['msg']).to eq('The username is already taken')
     end
 
     it 'stores password as bcrypt hash, not plaintext' do


### PR DESCRIPTION
## Description
Tilføjer RSpec integration tests for `POST /api/register` og retter en bug hvor ActiveRecord's `full_messages` præfikser feltnavnet i fejlbeskeder, inkonsistent med Flask-originalen.

## Related Issue
Closes #135

## Type of Change
- [x] Bug fix
- [x] New feature

## Changes Made
- `spec/integration/app_spec.rb`: 7 nye tests for `POST /api/register` (succesfuld registrering, password-mismatch, blanke felter, ugyldig email-format, duplikeret brugernavn, bcrypt-lagring)
- `spec/integration/app_spec.rb`: Omstruktureret fra `Session management`-wrapper til endpoint-baserede `describe`-blokke for bedre læsbarhed
- `app.rb`: `errors.full_messages.first` → `errors.first&.message` så fejlbeskeder returneres uden feltnavn-præfix (fx `"You have to enter a username"` frem for `"Username You have to enter a username"`)

## How to Test
1. `cd ruby-sinatra && bundle exec rspec spec/integration/app_spec.rb --format documentation`
2. Verificér at alle 12 tests er grønne
3. Verificér at `POST /api/register` med blankt brugernavn returnerer `"You have to enter a username"` (ikke `"Username You have to enter a username"`)

## Checklist
- [x] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)