### PR TITLE
chore: prod healthcheck + --wait in CD, document deploy MTTR, clean up legacy host

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -128,6 +128,10 @@ jobs:
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/opt/whoknows/app/nginx.conf
 
       # CD-CD
+      # --wait blocks until web service reports healthy (per healthcheck in
+      # docker-compose.prod.yml). --wait-timeout is the cap; if the container
+      # never becomes healthy within it, the deploy step fails fast with
+      # the real reason (unlike a fixed-duration smoke-test poll loop).
       - name: Deploy on server
         run: |
           ssh -i ~/.ssh/ssh_key \
@@ -135,7 +139,7 @@ jobs:
             set -euo pipefail
             cd /opt/whoknows/app
             docker compose -f docker-compose.prod.yml pull
-            docker compose -f docker-compose.prod.yml up -d --remove-orphans
+            docker compose -f docker-compose.prod.yml up -d --remove-orphans --wait --wait-timeout 600
           EOF
 
   # --- Post-deploy verification ---
@@ -146,24 +150,16 @@ jobs:
     needs: deploy
 
     steps:
+      # Deploy step's --wait already verified the container is healthy. Smoke
+      # test now just confirms the public URL through nginx + TLS works end to end.
       - name: Run smoke test on production
         run: |
           URL="https://monkknows.dk"
-
-          echo "Waiting for app to be ready..."
-
-          for i in $(seq 1 30); do
-            HTTP_STATUS=$(curl -o /dev/null -s -w "%{http_code}" -L $URL || echo "000")
-
-            if [ "$HTTP_STATUS" = "200" ]; then
-              echo "✅ CD Smoke test passed (status: $HTTP_STATUS)"
-              exit 0
-            fi
-
-            echo "Attempt $i: not ready (status: $HTTP_STATUS)"
-            sleep 2
-          done
-
-          echo "❌ CD Smoke test failed — app not ready in time"
-          exit 1
+          HTTP_STATUS=$(curl -o /dev/null -s -w "%{http_code}" -L --max-time 10 "$URL" || echo "000")
+          if [ "$HTTP_STATUS" = "200" ]; then
+            echo "✅ CD Smoke test passed (status: $HTTP_STATUS)"
+          else
+            echo "❌ CD Smoke test failed (status: $HTTP_STATUS)"
+            exit 1
+          fi
               

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,4 +29,10 @@ services:
       - DB_NAME=${DB_NAME}
       - SESSION_SECRET=${SESSION_SECRET}
       - OPENWEATHER_API_KEY=${OPENWEATHER_API_KEY}
+    healthcheck:
+      test: ["CMD-SHELL", "ruby -e \"require 'net/http'; res = Net::HTTP.get_response(URI('http://localhost:4567/health')); exit(res.is_a?(Net::HTTPSuccess) ? 0 : 1)\" || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 300s
     restart: unless-stopped

--- a/docs/choices-and-challenges/Choices and Challenges.md
+++ b/docs/choices-and-challenges/Choices and Challenges.md
@@ -1,7 +1,7 @@
 # Choices and Challenges
 
 **Written by:** Andreas, Nima & Sofie
- **Updated:** 20th April 2026
+ **Updated:** 30th April 2026
 
 ------
 
@@ -2772,3 +2772,106 @@ App-laget skriver til PostgreSQL. Azure Function har aldrig direkte databaseadga
 - Tekniske platformsbegrænsninger kan legitimere at revidere tidligere aftaler. Begrundelsen ("Python er officielt understøttet i Azure Functions, Ruby kræver custom handler") er konkret og afvejet.
 - API-medieret kommunikation frem for direkte DB-adgang er den rigtige enterprise-arkitektur: crawleren kan udskiftes, skaleres eller flyttes uden at røre databaselaget. Det er et bevidst design-valg, ikke blot convenience.
 - Hvis vi får tid til en runde efter Mandatory II: vælg én af mitigeringerne (sandsynligvis `--web.config.file` med basic auth — billigste at implementere uden infrastrukturændring).
+
+------
+
+## Deploy MTTR — fail-fast via Docker healthcheck frem for separat migrations-step
+
+### Context
+
+Ved deploy af PR #275 (30. april 2026) markerede CD-pipelinen deployet rødt selvom appen rent faktisk endte som healthy. Production smoke testen ventede 30 forsøg × 2 sekunder = 60 sekunder før den gav op. Den nye container havde 502 i ~8 minutter (cold gem-load anomali), så smoke testen fejlede længe før appen var klar. Forrige deploy (PR #269 d. 27. april) havde til sammenligning klaret cold-load på ~5 sekunder.
+
+Andreas2 lavede efterfølgende en MTTR-analyse med fire muligheder for at adressere symptomet. Vi skulle vælge én at implementere før Mandatory II.
+
+### Challenge
+
+De fire muligheder havde forskellige trade-offs:
+
+1. **Øg smoke test-timeout fra 60s → 300s+.** ~5 minutters arbejde. Maskerer problemet i stedet for at løse det — ægte fejl ville stadig vente 5 min på rødt resultat.
+2. **Tilføj Docker healthcheck til `docker-compose.prod.yml` + brug `up -d --wait` i CD.** ~15 minutters arbejde. Pipelinen blokerer indtil containeren er healthy, smoke testen rammer kun en faktisk klar app.
+3. **Kør `rake db:migrate` som separat one-off container i CD før `up -d`.** ~30 minutters arbejde. Den klassiske DevOps-løsning: gammel container fortsætter med at servere mens migrationer kører.
+4. **Blue-green deploy via Traefik/Caddy med to compose-projekter.** Flere timer. Nul nedetid. For tungt til kursusprojekt.
+
+Andreas2's første anbefaling var option #3 fordi det er det "rigtige" DevOps-mønster og giver et godt læringspoint. Diskussionen handlede om hvorvidt vi skulle vælge det "akademisk korrekte" svar eller det der faktisk fixer problemet.
+
+Investigation viste at præmissen bag option #3 ikke holdt: `rake db:migrate` på den live container tager 2 sekunder når caches er varme. Den dominerende cost under cold deploy er `Bundler.require` der loader ~80 gems fra cold disk — og det sker i den nye web-container uanset om migrationer er trukket ud i et separat step. Option #3's reelle gevinst er derfor ikke "migrationer er hurtigere", men at swap'en udskydes så brugere ikke ser 502 — hvilket option #1 ALTSÅ også løser fordi `--wait` blokerer indtil healthy.
+
+### Choice
+
+**Beslutning: Option #1 — Docker healthcheck på prod compose + `up -d --wait --wait-timeout 600` i CD.**
+
+Tilføjede samme healthcheck-blok som PR #274 indførte til `docker-compose.dev.yml`, med `start_period: 300s` for at give buffer til cold gem-load. Smoke testen blev simplificeret fra 30-attempt-poll-loop til én curl efter `--wait` returnerer.
+
+Option #3 blev oprettet som issue [#276](https://github.com/nasOps/MonkKnows/issues/276) til efter Mandatory II. Den er stadig værd at lave, men ikke nu.
+
+**Fordele:**
+
+- Fail-fast på den rigtige måde: Docker bekræfter healthy via `/health`, ikke en arbitrær timer
+- Fungerer for både hurtige (5s) og langsomme (8 min) deploys uden falske negatives
+- Ægte fejl (container starter aldrig) fanges efter healthcheck-buffer (~7.5 min) i stedet for 60s
+- Lille indsats: ~15 min, samme mønster vi allerede bruger i dev compose
+
+**Ulemper:**
+
+- Reducerer ikke bruger-synlig nedetid under cold-start anomalier — gammel container dræbes før ny er healthy. Issue #276 dækker det.
+- Loser ikke root cause for cold gem-load. Det er en separat optimering vi ikke har prioritet til nu.
+
+**Læring:**
+
+- "Det rigtige DevOps-svar" er ikke altid det rigtige svar for et konkret problem. Option #3 er et anerkendt mønster, men det løser ikke det vi havde galt: en CD der gættede på timing.
+- Fail-fast kommer i mange former. En Docker healthcheck er fail-fast for "har containeren bundet sig til porten?". En 60s timer er fail-fast for "ja eller nej, klar nu?". Førstnævnte er korrekt, sidstnævnte er en gætteleg.
+- At afvise et godt råd kræver et bedre råd plus målinger. Vi havde målte baselines (warm rake = 2s, PG round-trip = 9ms, forrige deploy = 5s), så vi kunne argumentere konkret for hvorfor option #1 dækker behovet.
+
+------
+
+## Legacy host-services efter Docker-migration
+
+### Context
+
+App-VM'en kører appen i Docker, men der lå stadig pre-Docker artefakter tilbage på host'en fra rbenv-tiden:
+
+- `whoknows.service` systemd-unit der prøvede at køre `bundle exec rackup` natively
+- `health_check.sh` cron der curled `localhost:4567/health` på host'en og kaldte `systemctl restart whoknows` ved fejl
+- `auto_deploy.sh` cron der prøvede `docker compose pull` hvert 5. minut
+
+De var blevet stående under Docker-migrationen "for safety" — ingen havde lyst til at slette noget der måske var nødvendigt. Infrastructure-map'en kategoriserede dem som "Dead Code" allerede, men de blev bevaret bevidst.
+
+### Challenge
+
+Under PR #275-investigationen fandt vi at de ikke bare var harmløst dead code. De var aktivt skadelige:
+
+- `health_check.sh`-curlen ramte en port der ikke findes på hosten (appen lytter kun inde i Docker-netværket), så den fejlede altid → `systemctl restart whoknows` kørte hver 5. minut → `whoknows.service` startede et bundle-process der fejlede med `Bundler::GemNotFound` (dev-gems ikke installeret i host'ens rbenv) → systemd's rate-limiter slog ind efter 5 hurtige restarts → service blev kicked igen 5 min senere
+- `auto_deploy.sh` fejlede stille med GHCR 401 (host mistede sin auth) og racet med CD-pipelinens egen SSH-deploy
+- En af `whoknows.service` crash-loop-bursts ramte præcis midt i CD-deployet (kl. 10:45 mens cold gem-load kørte) → ressource-konkurrence på en 1-vCPU/847 MiB VM bidrog til den 8-min anomali
+
+Spørgsmålet blev: skal vi slette dem helt, eller blot deaktivere dem så de kan reaktiveres?
+
+### Choice
+
+**Beslutning: Mask service + fjern cron-entries, men bevar filerne.**
+
+Konkret eksekveret 30. april:
+
+1. `whoknows.service` unit-fil flyttet til `/etc/systemd/system/whoknows.service.disabled-2026-04-30` og service'en `mask`'ed (symlink til `/dev/null`). `systemctl restart` kan nu ikke længere starte den.
+2. Root crontab backup'et til `/root/crontab-backup-2026-04-30.txt`. To linjer fjernet: `health_check.sh` og `auto_deploy.sh`.
+3. Beholdt: `db_backup.sh` (dagligt 03:00 — fungerer, backup'er den legacy SQLite-fil) og `monitor_logs.sh` (hvert 5. min — sender Discord-alerts, fungerer, men har separat hardcoded-webhook-issue).
+4. Cleanup-runbook gemt i `docs/runbooks/cleanup-legacy-host.md` med præcise kommandoer + rollback-procedure for hver enkelt ændring.
+
+**Fordele:**
+
+- Stopper cascaden hvor en broken cron kicker en broken service hver 5. minut
+- Frigør CPU+RAM under deploys (især vigtigt på en 1-vCPU/847 MiB VM)
+- Rollback er trivielt: `unmask` service og restore crontab fra backup. Intet er slettet.
+- Cleanup-runbook'en dokumenterer både hvad der blev gjort og hvorfor, så fremtidige ops-personer (eller fremtidige os) ikke skal genskabe ræsonnementet
+
+**Ulemper:**
+
+- Krævede SSH til prod for at eksekvere — ikke et automatisk repo-change. Vi har ingen Ansible/Terraform til at gøre den slags reproducerbart.
+- "Bevaret for rollback" betyder at filerne stadig ligger på host'en og kan forvirre fremtidige operatører hvis de ikke læser navngivnings-suffix'et.
+
+**Læring:**
+
+- Dead code er ikke nødvendigvis harmløst. Det vi troede var en passiv "ligger der bare"-rest, kostede os målbart ressource-budget under et deploy. Dead code burde fjernes når man har bekræftet det er dødt — ikke kategoriseres som "behold for sikkerheds skyld".
+- Migration-rester er en kendt antipattern. Når man flytter fra én infrastruktur til en anden (her: native systemd → Docker), skal cleanup-fasen være lige så bevidst som migration-fasen. Vi havde flagget det i infrastructure-map'en som "Kendt Gap" men aldrig adresseret det før det aktivt brød noget.
+- "Mask" er stærkere end "disable" i systemd. `disable` forhindrer kun start ved boot — `restart` ignorerer den. `mask` peger unit-filen til `/dev/null`, hvilket er den korrekte måde at sikre at en service aldrig starter, uanset hvordan den kaldes.
+- Et runbook med eksplicit rollback gør destructive operations på prod trygge nok at lave under tidspres. Det er hverdagens equivalent til "blue-green for ops-handlinger".

--- a/docs/infrastruktur/infrastructure-map.md
+++ b/docs/infrastruktur/infrastructure-map.md
@@ -1,6 +1,6 @@
 # MonkKnows Infrastructure Map
 
-_Sidst opdateret: 2026-04-23 (live survey via SSH)_
+_Sidst opdateret: 2026-04-30 (deploy MTTR investigation)_
 
 ---
 
@@ -134,7 +134,7 @@ Curler `http://localhost:4567/health` (5s timeout). Ved fejl: `systemctl restart
 `sqlite3 .backup` (WAL-safe) af `/opt/whoknows/data/whoknows.db` → `/opt/whoknows/backups/whoknows_TIMESTAMP.db`. Beholder 7 nyeste. Kører dagligt 03:00.
 
 **`/opt/whoknows/scripts/auto_deploy.sh`** (root, oprettet 2026-03-17)
-`docker compose pull` hvert 5. min. Hvis output indeholder "Pull complete": `docker compose up -d --no-build`. Alternativ til CD-pipelinens push-baserede deploy. Sidst aktiv: 2026-04-08.
+`docker compose pull` hvert 5. min. Hvis output indeholder "Pull complete": `docker compose up -d --no-build`. Alternativ til CD-pipelinens push-baserede deploy. **Status pr. 2026-04-30:** kører stadig hvert 5. min men fejler stille — host har ikke GHCR-auth-token, så pull returnerer `401 Unauthorized` (observeret 2026-04-30 10:40:05 UTC under deploy af PR #275, hvor det racet med CD'ens egen SSH-deploy).
 
 **`/usr/local/bin/monitor_logs.sh`** (root, oprettet 2026-03-19)
 Scanner `app-web-1`-logs siden sidste kørsel for `HTTP [45]xx` / `Error` / `error`. Ved match: sender Discord-webhook-alert. **Webhook-URL er hardcoded i scriptet.**
@@ -185,12 +185,72 @@ To serier med 7-dages rolling retention:
 ### Dead Code / Kendte problemer
 
 **`whoknows.service`** (systemd, `/etc/systemd/system/whoknows.service`):
-- Status: `failed` (disabled), sidst fejlet 2026-04-23 10:30 UTC (5 retries brugt op)
+- Status: `disabled` ved boot, men **kickes hver 5. min** af `health_check.sh` cron som kalder `systemctl restart whoknows` når den fejler at curle `localhost:4567/health` (porten findes kun inde i Docker-containerens netværk, så cronens curl rammer den aldrig).
 - Oprindelse: uge 3 rbenv-baseret direkte Sinatra-start
-- Hvorfor det fejler: appen kører nu i Docker; unit forsøger at starte ny instans på port 4567 + bruger gammel `DB_PATH`-env (SQLite, ikke Postgres)
-- Handling: bibeholdes bevidst, slettes ikke uden eksplicit godkendelse
+- Hvorfor unit'en fejler: appen kører nu i Docker; unit'en kører `bundle exec rackup` fra `/home/adminuser/.rbenv/` hvor dev-gems (`guard`, `pry`, `listen`, `ffi`…) ikke er installeret → fejler med `Bundler::GemNotFound`. Hver kick = 5 hurtige restart-forsøg før systemd rate-limiter slår ind (`StartLimitBurst`).
+- Bekræftet d. 2026-04-30 (10:40, 10:45, 10:50, 11:00 UTC — burst-mønstret ramte midt i CD-deployet og bidrog til ressource-konkurrence, se "Deploy MTTR observation" nedenfor).
+- Handling: bibeholdes bevidst, slettes ikke uden eksplicit godkendelse. Cleanup-runbook: `docs/runbooks/cleanup-legacy-host.md`.
 
 **Ruby-version mismatch:** CI pinner Ruby 3.2.3; kørende container-image bruger Ruby 3.2.11 (nyere patch).
+
+### Deploy MTTR observation (2026-04-30)
+
+PR #275 deploy'ede succesfuldt, men CD-pipelinens production smoke test markerede deployet rødt. App-containeren var 502 i ~8 minutter før Puma bandt sig til port 4567. Ingen kode-fejl — ren cold-start anomali.
+
+**Tidslinje (UTC):**
+
+| Tid | Hændelse |
+|---|---|
+| 10:38:33 | PR #275 merget → CD startede |
+| 10:40:01 | `auto_deploy.sh` cron kørte → `docker compose pull` fejlede med GHCR 401 (host mangler auth) |
+| 10:40:01–10:40:08 | `health_check.sh` cron kickede `whoknows.service` → 5 burst-restarts, alle fejlede med `Bundler::GemNotFound` |
+| 10:41:14 | Ny app-container startede (efter CD's SSH-deploy) |
+| 10:41:19 | `entrypoint.sh` printede "Running migrations..." |
+| 10:41:26 | CD smoke test begyndte at curle `https://monkknows.dk/` |
+| 10:42:42 | **Smoke test gav op efter 30 forsøg × 2s = 60s** → CD rød |
+| 10:45:01–10:45:08 | Endnu en `whoknows.service` burst (5 restart-forsøg under cold load) |
+| 10:49:10 | `bundle exec rake db:migrate` færdig efter **7m 51s** |
+| 10:49:14 | Puma bandt til port 4567, app begyndte at svare 200 |
+
+**Målte baselines (live på samme container, varm):**
+
+| Operation | Tid (varm) |
+|---|---|
+| `bundle exec rake db:migrate` (no-op) | ~2s |
+| `bundle exec ruby -e "puts :ok"` | ~815ms |
+| 100× PG round-trip VM1→VM2 | ~910ms (~9ms hver) |
+| `rake -T` (loader Rakefile + miljø) | ~1.8s |
+| Forrige succesfulde deploy (PR #269, 27/4) — smoke test | **5s** |
+
+**Hvad det IKKE var:**
+
+- ❌ Memory pressure (cgroup peak: 163 MiB / 256 MiB limit, ingen OOM, ingen `memory.events`)
+- ❌ Manglende gems (`bundle check` siger satisfied)
+- ❌ PG locks eller langsom DB (ingen rows i `pg_locks WHERE NOT granted`)
+- ❌ Eksterne API-kald i init (`config/environment.rb` er kun `Bundler.require`)
+- ❌ Pending migrations (schema_migrations matcher disk)
+- ❌ App.rb crash fra #275 (Rakefile loader ikke `app.rb`)
+
+**Mest sandsynlige årsag:**
+
+First-time disk page-in af 64 MB bundle-layer (~80 gems → tusindvis af små `.rb`-reads) på 1-vCPU/847 MiB-host, kombineret med ressource-konkurrence fra `whoknows.service` crash-loop-bursts der præcist ramte deploy-vinduet (10:40 og 10:45). Forrige deploys har klaret cold-load på sekunder — så det er en sammensat anomali, ikke kronisk.
+
+**Bidragende host-side rod:**
+
+Det at `whoknows.service` overhovedet bliver kicked hver 5. min er et symptom på misalignment efter Docker-migrationen — health-check'et curler en port der ikke findes på hosten, og "fix"-handlingen restarter en service der ikke længere er meningen at køre. Cleanup: se `docs/runbooks/cleanup-legacy-host.md`.
+
+### Deploy improvements (overvejes — ikke implementeret)
+
+Inspireret af MTTR-analyse fra Andreas2 (kollega) + investigation 2026-04-30:
+
+| # | Tiltag | Effort | Effekt | Vurdering |
+|---|---|---|---|---|
+| 1 | Tilføj `healthcheck` til `docker-compose.prod.yml` (samme mønster som PR #274 indførte til dev) + brug `docker compose up -d --wait` i CD-deploy-step | ~15 min | Deploy blokerer indtil container er healthy. Smoke test rammer kun en faktisk klar app. Ægte fail-fast via Docker. | **Anbefalet quick-win** |
+| 2 | Øg smoke test-timeout fra 60s → 300s+ | ~5 min | Maskerer langsomme deploys i stedet for at fejle dem. Kombineret med #1 er det gratis safety. | Lavt værd alene |
+| 3 | Kør `rake db:migrate` som separat one-off container i CD før `up -d` | ~30 min | Gammel container fortsætter med at betjene trafik mens migrationer kører. Reducerer **bruger-synlig** nedetid. | Godt læringspoint, men løser ikke dominant cost (gem cold-load sker stadig) |
+| 4 | Blue-green deploy via Traefik/Caddy med to compose-projekter | flere timer | Nul nedetid, ægte fail-fast. | For tungt til kursusprojekt |
+
+Bemærk: option 3's hovedgevinst er ikke "migrations er hurtigere" — `rake db:migrate` tager 2s varm. Gevinsten er at swap'en udskydes til ny container er warm-loaded, så brugere ser ikke 502.
 
 ---
 

--- a/docs/infrastruktur/infrastructure-map.md
+++ b/docs/infrastruktur/infrastructure-map.md
@@ -62,7 +62,7 @@ SSH-config: `~/.ssh/config` — begge bruger samme SSH-nøgle. Appens PostgreSQL
 | `app-web-1` | `ghcr.io/nasops/monkknows:latest` | Up ~45h, **healthy** | 4567 (intern kun) |
 | `app-nginx-1` | `nginx:alpine` (1.29.8) | Up 5 dage | `0.0.0.0:80`, `0.0.0.0:443` |
 
-**Healthcheck (`app-web-1`):** `ruby -e "require 'net/http'; ..."` → `GET http://localhost:4567/health` — interval 30s, timeout 5s, 3 retries. Status: passing (FailingStreak: 0).
+**Healthcheck (`app-web-1`):** `ruby -e "require 'net/http'; ..."` → `GET http://localhost:4567/health`. Defineret i `docker-compose.prod.yml` (overrider Dockerfile's HEALTHCHECK): interval 5s, timeout 3s, retries 30, **start_period 300s** (giver buffer til cold gem-load efter fresh image-pull). CD's deploy-step bruger `docker compose up -d --wait --wait-timeout 600` så pipelinen blokerer indtil healthy.
 
 **Volume mount (`app-web-1`):** `/opt/whoknows/data/logging` → `/app/db/logging` (rw)
 
@@ -80,6 +80,7 @@ SSH-config: `~/.ssh/config` — begge bruger samme SSH-nøgle. Appens PostgreSQL
 - Image: `ghcr.io/nasops/monkknows:latest`, intern port 4567 (ikke publiceret til host)
 - Volume: `/opt/whoknows/data/logging:/app/db/logging`
 - Limits: 256 MB RAM, 0.50 CPU
+- `healthcheck`: ruby net/http mod `/health`, interval 5s, timeout 3s, retries 30, start_period 300s
 - `restart: unless-stopped`
 - Env: `RACK_ENV=production` + alle 6 nøgler fra `.env`
 
@@ -127,14 +128,14 @@ Ingen upstream-blok, ingen rate limiting, ingen caching-direktiver.
 
 ### Scripts
 
-**`/opt/whoknows/scripts/health_check.sh`** (root, oprettet 2026-02-24)
-Curler `http://localhost:4567/health` (5s timeout). Ved fejl: `systemctl restart whoknows` — vil altid fejle fordi `whoknows.service` er broken. Logger OK-entries kun hvert 6. time.
+**`/opt/whoknows/scripts/health_check.sh`** (root, oprettet 2026-02-24, **cron-entry fjernet 2026-04-30**)
+Curler `http://localhost:4567/health` (5s timeout). Ved fejl: `systemctl restart whoknows` — vil altid fejle fordi appen kun lytter inde i Docker-netværket. Cron-entry fjernet 2026-04-30 (se `docs/runbooks/cleanup-legacy-host.md`); script-filen ligger stadig i `/opt/whoknows/scripts/` for reference.
 
 **`/opt/whoknows/scripts/db_backup.sh`** (root, oprettet 2026-02-24)
 `sqlite3 .backup` (WAL-safe) af `/opt/whoknows/data/whoknows.db` → `/opt/whoknows/backups/whoknows_TIMESTAMP.db`. Beholder 7 nyeste. Kører dagligt 03:00.
 
-**`/opt/whoknows/scripts/auto_deploy.sh`** (root, oprettet 2026-03-17)
-`docker compose pull` hvert 5. min. Hvis output indeholder "Pull complete": `docker compose up -d --no-build`. Alternativ til CD-pipelinens push-baserede deploy. **Status pr. 2026-04-30:** kører stadig hvert 5. min men fejler stille — host har ikke GHCR-auth-token, så pull returnerer `401 Unauthorized` (observeret 2026-04-30 10:40:05 UTC under deploy af PR #275, hvor det racet med CD'ens egen SSH-deploy).
+**`/opt/whoknows/scripts/auto_deploy.sh`** (root, oprettet 2026-03-17, **cron-entry fjernet 2026-04-30**)
+`docker compose pull` hvert 5. min. Var alternativ til CD-pipelinens push-baserede deploy, men host'en mistede GHCR-auth-token og pull returnerede `401 Unauthorized` (observeret 2026-04-30 10:40:05 UTC under deploy af PR #275 hvor det racet med CD'ens egen SSH-deploy). Cron-entry fjernet 2026-04-30; script-filen bevaret for reference.
 
 **`/usr/local/bin/monitor_logs.sh`** (root, oprettet 2026-03-19)
 Scanner `app-web-1`-logs siden sidste kørsel for `HTTP [45]xx` / `Error` / `error`. Ved match: sender Discord-webhook-alert. **Webhook-URL er hardcoded i scriptet.**
@@ -145,11 +146,13 @@ Manuel devutil — tester om en GitHub PAT har korrekte scopes til GHCR. Kører 
 ### Cron Jobs (root)
 
 ```cron
-*/5 * * * *   /opt/whoknows/scripts/health_check.sh >> /var/log/whoknows/health_check.log 2>&1
 0   3 * * *   /opt/whoknows/scripts/db_backup.sh >> /var/log/whoknows/db_backup.log 2>&1
-*/5 * * * *   /opt/whoknows/scripts/auto_deploy.sh >> /var/log/whoknows/deploy.log 2>&1
 */5 * * * *   /usr/local/bin/monitor_logs.sh >> /var/log/whoknows_monitor.log 2>&1
 ```
+
+**Fjernet 2026-04-30** (gemt backup: `/root/crontab-backup-2026-04-30.txt`):
+- `*/5 * * * * /opt/whoknows/scripts/health_check.sh` — curlede en port der ikke findes på host'en, og kickede `whoknows.service` i en crash-loop
+- `*/5 * * * * /opt/whoknows/scripts/auto_deploy.sh` — fejlede med GHCR 401 og racet med CD-pipelinens deploy
 
 **adminuser crontab:** tom.
 
@@ -184,12 +187,11 @@ To serier med 7-dages rolling retention:
 
 ### Dead Code / Kendte problemer
 
-**`whoknows.service`** (systemd, `/etc/systemd/system/whoknows.service`):
-- Status: `disabled` ved boot, men **kickes hver 5. min** af `health_check.sh` cron som kalder `systemctl restart whoknows` når den fejler at curle `localhost:4567/health` (porten findes kun inde i Docker-containerens netværk, så cronens curl rammer den aldrig).
-- Oprindelse: uge 3 rbenv-baseret direkte Sinatra-start
-- Hvorfor unit'en fejler: appen kører nu i Docker; unit'en kører `bundle exec rackup` fra `/home/adminuser/.rbenv/` hvor dev-gems (`guard`, `pry`, `listen`, `ffi`…) ikke er installeret → fejler med `Bundler::GemNotFound`. Hver kick = 5 hurtige restart-forsøg før systemd rate-limiter slår ind (`StartLimitBurst`).
-- Bekræftet d. 2026-04-30 (10:40, 10:45, 10:50, 11:00 UTC — burst-mønstret ramte midt i CD-deployet og bidrog til ressource-konkurrence, se "Deploy MTTR observation" nedenfor).
-- Handling: bibeholdes bevidst, slettes ikke uden eksplicit godkendelse. Cleanup-runbook: `docs/runbooks/cleanup-legacy-host.md`.
+**`whoknows.service`** (systemd, **masked 2026-04-30**):
+- Status: `masked` (symlink til `/dev/null`). `systemctl start/restart` returnerer fejl uden at gøre noget. Bekræftet 2026-04-30 11:23 UTC.
+- Oprindelse: uge 3 rbenv-baseret direkte Sinatra-start fra før Docker-migrationen.
+- Hvorfor unit'en fejlede: appen kører nu i Docker; unit'en kørte `bundle exec rackup` fra `/home/adminuser/.rbenv/` hvor dev-gems (`guard`, `pry`, `listen`, `ffi`…) ikke er installeret → fejlede med `Bundler::GemNotFound`. Op til 2026-04-30 blev den kicked hver 5. min af `health_check.sh` cron, hvilket gav 5-restart-bursts (en af disse bursts ramte midt i CD-deployet, se "Deploy MTTR observation" nedenfor).
+- Backup af unit-filen ligger i `/etc/systemd/system/whoknows.service.disabled-2026-04-30` for rollback.
 
 **Ruby-version mismatch:** CI pinner Ruby 3.2.3; kørende container-image bruger Ruby 3.2.11 (nyere patch).
 
@@ -239,16 +241,16 @@ First-time disk page-in af 64 MB bundle-layer (~80 gems → tusindvis af små `.
 
 Det at `whoknows.service` overhovedet bliver kicked hver 5. min er et symptom på misalignment efter Docker-migrationen — health-check'et curler en port der ikke findes på hosten, og "fix"-handlingen restarter en service der ikke længere er meningen at køre. Cleanup: se `docs/runbooks/cleanup-legacy-host.md`.
 
-### Deploy improvements (overvejes — ikke implementeret)
+### Deploy improvements
 
 Inspireret af MTTR-analyse fra Andreas2 (kollega) + investigation 2026-04-30:
 
-| # | Tiltag | Effort | Effekt | Vurdering |
+| # | Tiltag | Status | Effort | Effekt |
 |---|---|---|---|---|
-| 1 | Tilføj `healthcheck` til `docker-compose.prod.yml` (samme mønster som PR #274 indførte til dev) + brug `docker compose up -d --wait` i CD-deploy-step | ~15 min | Deploy blokerer indtil container er healthy. Smoke test rammer kun en faktisk klar app. Ægte fail-fast via Docker. | **Anbefalet quick-win** |
-| 2 | Øg smoke test-timeout fra 60s → 300s+ | ~5 min | Maskerer langsomme deploys i stedet for at fejle dem. Kombineret med #1 er det gratis safety. | Lavt værd alene |
-| 3 | Kør `rake db:migrate` som separat one-off container i CD før `up -d` | ~30 min | Gammel container fortsætter med at betjene trafik mens migrationer kører. Reducerer **bruger-synlig** nedetid. | Godt læringspoint, men løser ikke dominant cost (gem cold-load sker stadig) |
-| 4 | Blue-green deploy via Traefik/Caddy med to compose-projekter | flere timer | Nul nedetid, ægte fail-fast. | For tungt til kursusprojekt |
+| 1 | Tilføj `healthcheck` til `docker-compose.prod.yml` (samme mønster som PR #274 indførte til dev) + brug `docker compose up -d --wait --wait-timeout 600` i CD-deploy-step | ✅ **Implementeret 2026-04-30** (denne branch) | ~15 min | Deploy blokerer indtil container er healthy. Smoke test rammer kun en faktisk klar app. Ægte fail-fast via Docker. |
+| 2 | Øg smoke test-timeout fra 60s → 300s+ | ⏭️ Ikke nødvendig — option #1 dækker det. Smoke test simplificeret til én curl efter `--wait`. | ~5 min | Maskerer langsomme deploys i stedet for at fejle dem. |
+| 3 | Kør `rake db:migrate` som separat one-off container i CD før `up -d` | 📋 Tracked i [#276](https://github.com/nasOps/MonkKnows/issues/276) (efter Mandatory II) | ~30 min | Gammel container fortsætter med at betjene trafik mens migrationer kører. Reducerer **bruger-synlig** nedetid. |
+| 4 | Blue-green deploy via Traefik/Caddy med to compose-projekter | ❌ Ikke planlagt | flere timer | Nul nedetid, ægte fail-fast. For tungt til kursusprojekt. |
 
 Bemærk: option 3's hovedgevinst er ikke "migrations er hurtigere" — `rake db:migrate` tager 2s varm. Gevinsten er at swap'en udskydes til ny container er warm-loaded, så brugere ser ikke 502.
 
@@ -463,13 +465,13 @@ Se: `docs/specs/2026-04-28-scraping-indexing-design.md`
 | Problem | Konsekvens | VM |
 |---|---|---|
 | Port 5432, 9090, 3000 eksponeret på `0.0.0.0` uden Azure NSG-whitelist | Alle tre services tilgængelige fra internet | Monitoring |
-| `health_check.sh` kalder `systemctl restart whoknows` ved fejl | Vil altid fejle — restarter ikke den rigtige container | App |
+| ~~`health_check.sh` kalder `systemctl restart whoknows` ved fejl~~ ✅ Cron-entry fjernet 2026-04-30 | ~~Vil altid fejle — restarter ikke den rigtige container~~ | App |
 | TLS cert renewal er ikke fuldt automatiseret | Nginx-container genstartes ikke efter `certbot.timer` → ny cert indlæses ikke | App |
 | SQLite logging-DB (`data/logging/logging.sqlite3`) har ingen backup | Søgelog kan gå tabt ved disk-fejl | App |
 | Discord webhook-URL hardcoded i `monitor_logs.sh` | Scriptet fejler lydløst hvis webhook ændres | App |
-| `auto_deploy.sh` og `cd.yml` kan konflikte | Redundant pull-restart i samme 5-minutters vindue | App |
+| ~~`auto_deploy.sh` og `cd.yml` kan konflikte~~ ✅ Cron-entry fjernet 2026-04-30 | ~~Redundant pull-restart i samme 5-minutters vindue~~ | App |
 | Ingen `node_exporter` på nogen VM | Ingen host-level metrics (CPU, mem, disk) i Grafana | Begge |
 | Ingen Alertmanager / alert-regler | Prometheus samler data men sender ingen alerts | Monitoring |
 | Grafana kører på plain HTTP (port 3000) | Ingen TLS-fronting på Grafana UI | Monitoring |
 | Ruby 3.2.3 (CI) vs. Ruby 3.2.11 (kørende image) | Minor version mismatch | App |
-| `whoknows.service` i `failed` state | Dead code — forvirrer ops | App |
+| ~~`whoknows.service` i `failed` state~~ ✅ Masked 2026-04-30 (unit-fil flyttet til `.disabled-2026-04-30`) | ~~Dead code — forvirrer ops~~ | App |

--- a/docs/runbooks/cleanup-legacy-host.md
+++ b/docs/runbooks/cleanup-legacy-host.md
@@ -1,0 +1,123 @@
+# Cleanup: Legacy host-services på App-VM
+
+_Oprettet: 2026-04-30_
+
+Efter Docker-migrationen kører appen udelukkende i containere, men der er stadig pre-Docker host-services tilbage på App-VM'en. De udfører intet meningsfuldt arbejde længere, og under CD-deploy af PR #275 (2026-04-30) bidrog de målbart til en 8-minutters cold-start anomali — se "Deploy MTTR observation" i [`docs/infrastruktur/infrastructure-map.md`](../infrastruktur/infrastructure-map.md).
+
+Denne runbook fjerner dem. Kommandoer skal køres manuelt over SSH; intet i denne fil bliver kørt automatisk.
+
+---
+
+## Hvad ryddes op
+
+| Komponent | Type | Tilstand i dag | Action |
+|---|---|---|---|
+| `whoknows.service` | systemd unit | Crash-looper hver 5. min (kicket af `health_check.sh`). Kører `bundle exec rackup` natively, fejler `Bundler::GemNotFound`. | Mask + slet unit-fil |
+| `/opt/whoknows/scripts/health_check.sh` | cron `*/5 * * * *` | Curler `localhost:4567` på hosten — porten findes kun i Docker-netværket. Kalder `systemctl restart whoknows` ved fejl → triggerer crash-loop. | Fjern cron-entry. Script kan beholdes som reference. |
+| `/opt/whoknows/scripts/auto_deploy.sh` | cron `*/5 * * * *` | `docker compose pull` hvert 5. min. Fejler stille med GHCR 401 (host mangler auth). Racer med CD-pipelinens egen SSH-deploy. | Fjern cron-entry. Script kan beholdes som reference. |
+| `/usr/local/bin/monitor_logs.sh` | cron `*/5 * * * *` | Fungerer (sender Discord-alerts). Hardcoded webhook-URL — separat issue, ikke del af denne cleanup. | **Beholdes** |
+| `/opt/whoknows/scripts/db_backup.sh` | cron `0 3 * * *` | Backup'er `/opt/whoknows/data/whoknows.db` (SQLite). PostgreSQL backups kommer fra Monitoring-VM. | **Beholdes** (legacy SQLite-fil bibeholdes bevidst — Nima) |
+
+---
+
+## Pre-checks (læs før du gør noget)
+
+```bash
+# Bekræft du er på rigtig host
+ssh -i ~/.ssh/id_rsa adminuser@4.225.161.111 'hostname; uptime'
+
+# Bekræft Docker-appen kører healthy
+ssh -i ~/.ssh/id_rsa adminuser@4.225.161.111 'docker ps --format "table {{.Names}}\t{{.Status}}"'
+
+# Bekræft https://monkknows.dk/ svarer 200
+curl -sS -o /dev/null -w "HTTP %{http_code}\n" https://monkknows.dk/
+```
+
+Forventet output: `app-web-1` `Up X (healthy)`, monkknows.dk → `HTTP 200`.
+
+**Hvis app-web-1 ikke er healthy, STOP.** Cleanup'en er ikke en nødløsning — løs container-issue først.
+
+---
+
+## Step 1 — Stop og mask `whoknows.service`
+
+`disable` er ikke nok: `health_check.sh` kalder `systemctl restart whoknows`, og `restart` ignorerer `disable`. `mask` peger unit-filen til `/dev/null` så den ikke kan startes overhovedet.
+
+```bash
+ssh -i ~/.ssh/id_rsa adminuser@4.225.161.111 << 'EOF'
+sudo systemctl stop whoknows.service
+sudo systemctl disable whoknows.service
+sudo systemctl mask whoknows.service
+sudo systemctl status whoknows.service --no-pager
+EOF
+```
+
+Forventet output: `Loaded: masked (Reason: Unit whoknows.service is masked.)`. Active: `inactive (dead)`.
+
+---
+
+## Step 2 — Fjern de to cron-entries
+
+Cron'en ligger i root's crontab. Fjern de to linjer der refererer `health_check.sh` og `auto_deploy.sh`.
+
+```bash
+# Tag backup af crontab først
+ssh -i ~/.ssh/id_rsa adminuser@4.225.161.111 'sudo crontab -l > /tmp/crontab-backup-$(date +%Y%m%d).txt && sudo crontab -l'
+```
+
+Slet de to linjer manuelt:
+
+```bash
+ssh -t -i ~/.ssh/id_rsa adminuser@4.225.161.111 'sudo crontab -e'
+```
+
+Linjer der skal fjernes:
+
+```cron
+*/5 * * * * /opt/whoknows/scripts/health_check.sh >> /var/log/whoknows/health_check.log 2>&1
+*/5 * * * * /opt/whoknows/scripts/auto_deploy.sh >> /var/log/whoknows/deploy.log 2>&1
+```
+
+Linjer der **beholdes**:
+
+```cron
+*/5 * * * * /usr/local/bin/monitor_logs.sh >> /var/log/whoknows_monitor.log 2>&1
+0   3 * * * /opt/whoknows/scripts/db_backup.sh >> /var/log/whoknows/db_backup.log 2>&1
+```
+
+---
+
+## Step 3 — Verifikation
+
+```bash
+# Bekræft at whoknows.service ikke længere bliver kicket
+ssh -i ~/.ssh/id_rsa adminuser@4.225.161.111 'sudo journalctl -u whoknows.service --since "10 min ago" --no-pager'
+
+# Bekræft cron er ren
+ssh -i ~/.ssh/id_rsa adminuser@4.225.161.111 'sudo crontab -l'
+
+# Bekræft monkknows.dk stadig svarer
+curl -sS -o /dev/null -w "HTTP %{http_code}\n" https://monkknows.dk/
+```
+
+Vent 10 minutter og tjek igen at journalctl ikke viser nye `whoknows.service`-events.
+
+---
+
+## Rollback
+
+Hvis noget går galt:
+
+```bash
+# Genoptag whoknows.service (ikke anbefalet, men muligt)
+ssh -i ~/.ssh/id_rsa adminuser@4.225.161.111 'sudo systemctl unmask whoknows.service'
+
+# Genskab crontab fra backup
+ssh -i ~/.ssh/id_rsa adminuser@4.225.161.111 'sudo crontab /tmp/crontab-backup-YYYYMMDD.txt'
+```
+
+---
+
+## Næste skridt (separat opgave)
+
+Når host-rod'et er væk, er det den rigtige tid til at implementere fix #1 fra "Deploy improvements"-tabellen i `infrastructure-map.md`: tilføj `healthcheck` til `docker-compose.prod.yml` + brug `up -d --wait` i CD's deploy-step. Det giver ægte fail-fast og fjerner `health_check.sh`-rollen helt.

--- a/docs/runbooks/cleanup-legacy-host.md
+++ b/docs/runbooks/cleanup-legacy-host.md
@@ -1,10 +1,12 @@
 # Cleanup: Legacy host-services på App-VM
 
-_Oprettet: 2026-04-30_
+_Oprettet: 2026-04-30 — **udført samme dag kl. ~11:23 UTC**_
 
-Efter Docker-migrationen kører appen udelukkende i containere, men der er stadig pre-Docker host-services tilbage på App-VM'en. De udfører intet meningsfuldt arbejde længere, og under CD-deploy af PR #275 (2026-04-30) bidrog de målbart til en 8-minutters cold-start anomali — se "Deploy MTTR observation" i [`docs/infrastruktur/infrastructure-map.md`](../infrastruktur/infrastructure-map.md).
+> **Status:** ✅ Eksekveret 2026-04-30. `whoknows.service` er masked (unit-fil flyttet til `whoknows.service.disabled-2026-04-30`), og de to broken cron-entries er fjernet. Crontab-backup ligger i `/root/crontab-backup-2026-04-30.txt` på App-VM. Beholdt som reference + rollback-procedure.
 
-Denne runbook fjerner dem. Kommandoer skal køres manuelt over SSH; intet i denne fil bliver kørt automatisk.
+Efter Docker-migrationen kører appen udelukkende i containere, men der var stadig pre-Docker host-services tilbage på App-VM'en. De udførte intet meningsfuldt arbejde længere, og under CD-deploy af PR #275 (2026-04-30) bidrog de målbart til en 8-minutters cold-start anomali — se "Deploy MTTR observation" i [`docs/infrastruktur/infrastructure-map.md`](../infrastruktur/infrastructure-map.md).
+
+Denne runbook fjerner dem. Kommandoer skulle køres manuelt over SSH; intet i denne fil bliver kørt automatisk.
 
 ---
 
@@ -43,39 +45,35 @@ Forventet output: `app-web-1` `Up X (healthy)`, monkknows.dk → `HTTP 200`.
 
 `disable` er ikke nok: `health_check.sh` kalder `systemctl restart whoknows`, og `restart` ignorerer `disable`. `mask` peger unit-filen til `/dev/null` så den ikke kan startes overhovedet.
 
+**Vigtig:** Hvis unit-filen ligger som regulær fil i `/etc/systemd/system/`, fejler `mask` med "File already exists". Den skal flyttes først:
+
 ```bash
 ssh -i ~/.ssh/id_rsa adminuser@4.225.161.111 << 'EOF'
-sudo systemctl stop whoknows.service
-sudo systemctl disable whoknows.service
+set -e
+sudo systemctl stop whoknows.service || true
+sudo systemctl disable whoknows.service || true
+sudo mv /etc/systemd/system/whoknows.service /etc/systemd/system/whoknows.service.disabled-$(date +%Y-%m-%d)
+sudo systemctl daemon-reload
 sudo systemctl mask whoknows.service
 sudo systemctl status whoknows.service --no-pager
 EOF
 ```
 
-Forventet output: `Loaded: masked (Reason: Unit whoknows.service is masked.)`. Active: `inactive (dead)`.
+Forventet output: `Loaded: masked (Reason: Unit whoknows.service is masked.)`.
 
 ---
 
 ## Step 2 — Fjern de to cron-entries
 
-Cron'en ligger i root's crontab. Fjern de to linjer der refererer `health_check.sh` og `auto_deploy.sh`.
+Cron'en ligger i root's crontab. Backup først, så filtrér de to linjer der refererer `health_check.sh` og `auto_deploy.sh`:
 
 ```bash
-# Tag backup af crontab først
-ssh -i ~/.ssh/id_rsa adminuser@4.225.161.111 'sudo crontab -l > /tmp/crontab-backup-$(date +%Y%m%d).txt && sudo crontab -l'
-```
-
-Slet de to linjer manuelt:
-
-```bash
-ssh -t -i ~/.ssh/id_rsa adminuser@4.225.161.111 'sudo crontab -e'
-```
-
-Linjer der skal fjernes:
-
-```cron
-*/5 * * * * /opt/whoknows/scripts/health_check.sh >> /var/log/whoknows/health_check.log 2>&1
-*/5 * * * * /opt/whoknows/scripts/auto_deploy.sh >> /var/log/whoknows/deploy.log 2>&1
+ssh -i ~/.ssh/id_rsa adminuser@4.225.161.111 'sudo bash -c "
+set -e
+crontab -l > /root/crontab-backup-$(date +%Y-%m-%d).txt
+grep -vE \"health_check\\.sh|auto_deploy\\.sh\" /root/crontab-backup-$(date +%Y-%m-%d).txt | crontab -
+crontab -l
+"'
 ```
 
 Linjer der **beholdes**:


### PR DESCRIPTION
## Summary

Closes the deploy MTTR signal gap that PR #275 surfaced (CD reported red even though deploy succeeded — app needed ~8 min to bind to port 4567 but smoke test only waited 60s). Also cleans up legacy host-services that were actively interfering with the deploy.

## Changes

### Code

- **`docker-compose.prod.yml`** — adds `healthcheck` block on `web` service (same `/health` ruby net/http pattern PR #274 added to dev compose). `start_period: 300s` to absorb cold gem-load anomalies.
- **`.github/workflows/cd.yml`** — deploy step now uses `docker compose up -d --wait --wait-timeout 600`. Pipeline blocks until container reports healthy. Smoke test simplified from 30-attempt poll loop to a single curl after `--wait` returns.

### Docs

- **`docs/infrastruktur/infrastructure-map.md`** — new "Deploy MTTR observation (2026-04-30)" section with full timeline, measured baselines, ruled-out hypotheses, and likely cause. New "Deploy improvements" table tracking option #1 (this PR), #2 (subsumed), #3 ([#276](https://github.com/nasOps/MonkKnows/issues/276)), and #4 (out of scope). Status updates on `whoknows.service`, `health_check.sh`, `auto_deploy.sh` reflecting the executed cleanup.
- **`docs/runbooks/cleanup-legacy-host.md`** — new runbook with the exact commands used to mask `whoknows.service` and remove the two broken cron entries, plus rollback procedure. Marked as executed 2026-04-30.
- **`docs/choices-and-challenges/Choices and Challenges.md`** — two new entries: (1) why we picked option #1 over @Andreas2's preferred option #3 — including the measurements that made the argument concrete; (2) why we promoted the legacy host stuff from "harmless dead code" to "actively cleaned up".

### Production server (executed 2026-04-30 ~11:23 UTC)

- `whoknows.service` masked (unit file moved to `whoknows.service.disabled-2026-04-30`)
- Root crontab backup: `/root/crontab-backup-2026-04-30.txt`
- Removed cron entries: `health_check.sh`, `auto_deploy.sh`
- Kept: `db_backup.sh`, `monitor_logs.sh`

## Test plan

- [x] Verify YAML valid (already done locally — `ruby -ryaml`)
- [ ] Merge → CD pipeline runs → confirm `Deploy on server` step blocks until healthy and CD shows green
- [ ] Verify `https://monkknows.dk/` still responds 200 after deploy
- [ ] After 10 min, verify `journalctl -u whoknows.service` shows no new restart attempts (cleanup confirmation)

## Discussion points for review

- @Andreas2 — the "Deploy improvements" table in `infrastructure-map.md` and the C&C entry on the MTTR decision capture our discussion. Issue #276 tracks option #3 as the next iteration. Push back if anything misrepresents your reasoning.
- Healthcheck `start_period: 300s` is conservative (covers the 8-min anomaly minus some). Open to bringing it down once we have a few green deploys to confirm cold-start is back to ~5s baseline.

## References

- Investigation context: see `docs/infrastruktur/infrastructure-map.md` → "Deploy MTTR observation (2026-04-30)"
- Follow-up: [#276](https://github.com/nasOps/MonkKnows/issues/276) — option #3 (separate migrations container)
- Related: PR #274 (introduced healthcheck pattern in dev), PR #275 (deploy that triggered the investigation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced deployment health verification with container-level healthchecks
  * Streamlined post-deployment validation process
  * Updated deployment infrastructure and operational documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->