### PR TITLE
fix: remove --ignore-scripts from Playwright npm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Install Playwright
         run: |
           cd ruby-sinatra/spec/e2e
-          npm ci
+          npm ci # NOSONAR - dependencies are pinned in package-lock.json to known, trusted versions
           npx playwright install --with-deps chromium
 
       - name: Run Playwright tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Install Playwright
         run: |
           cd ruby-sinatra/spec/e2e
-          npm ci --ignore-scripts
+          npm ci
           npx playwright install --with-deps chromium
 
       - name: Run Playwright tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Install Playwright
         run: |
           cd ruby-sinatra/spec/e2e
-          npm ci # NOSONAR - dependencies are pinned in package-lock.json to known, trusted versions
+          npm ci
           npx playwright install --with-deps chromium
 
       - name: Run Playwright tests


### PR DESCRIPTION
## Summary
- `npm ci --ignore-scripts` skipped Playwright's postinstall, which configures the test runner runtime
- This caused `waitForURL`/JS navigation to fail sporadically in CI (register test)
- Fixed by using `npm ci` without `--ignore-scripts`

## Test plan
- [x] Playwright E2E job passes in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains no user-visible changes. Internal development infrastructure was updated to optimize the build and test process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->