### PR TITLE
docs: software quality tool reflections

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners for all files
-* @Gabel1998 @sobr0002 @NimaAB
+* @Gabel1998 @sobr0002 @hajisan
 
 # CI/CD and DevOps
 .github/ @Gabel1998

--- a/docs/choices-and-challenges/Choices and Challenges.md
+++ b/docs/choices-and-challenges/Choices and Challenges.md
@@ -2347,7 +2347,8 @@ Sofies logging-system bruger en separat SQLite-database via `LoggingBase`. Ved c
 - `BUNDLE_WITHOUT` i Dockerfile gør det kritisk at gems er i den rigtige group
 - `__dir__` er `nil` i ERB/YAML-kontekst — brug aldrig `__dir__` i `database.yml`. Relative stier eller ENV-variabler er sikrere
 - Smoke tests i CD pipelinen fangede fejlen — uden dem ville vi først opdage det manuelt
-
+'
+- '
 ------
 
 ## Tilgængelighed / Accessibility (Issue #242)

--- a/docs/software-quality/software-quality.md
+++ b/docs/software-quality/software-quality.md
@@ -1,5 +1,74 @@
 
+# Brakeman
 
+Brakeman er en statisk sikkerhedsscanner til Ruby, der analyserer kildekoden for kendte sårbarheder som SQL injection og XSS. Vi er enige i fundene og har rettet de legitime advarsler. Brakeman er kendt for at producere falske positive, særligt around mass assignment og dynamiske queries — disse har vi vurderet og bevidst ignoreret, da de ikke var reelle sårbarheder i vores kontekst.
+
+# CodeRabbit
+
+CodeRabbit gennemgår automatisk alle PRs og kommenterer på potentielle problemer i koden. Vi er enige i størstedelen af fundene og har aktivt handlet på dem. Vi har ignoreret kommentarer, der omhandlede strukturen i Choices and Challenges.md samt nitpicks-kommentarer.
+
+
+**41 PRs** med CodeRabbit-aktivitet fundet (ca. 153 kode-kommentarer + 95 issue-kommentarer).
+
+
+
+## Enige i og rettet
+
+**PR #96 – Nginx port-eksponering** Port 4567 var stadig eksponeret på web-servicen, stik imod PRens formål. Rettet med commit "Removed exposing the ports".
+
+**PR #106 – JSON type-validering** CodeRabbit pegede på at `.each { |k, v| }` ville crashe hvis parsed JSON ikke var et hash (array/primitiver). Rettet med hash-validering + content-type header på parse-fejl. Noteret i Choices & Challenges.
+
+**PR #162 – CSP + SameSite cookies (delvis)** Konfliktende CSP-headers og forkert SameSite-konfiguration. Rettet med en commit specifikt til det — men efterfølgende måtte headerne gøres mindre restriktive af funktionalitetshensyn.
+
+**PR #170 – SSH StrictHostKeyChecking** `StrictHostKeyChecking=no` i CD-pipelinen. Rettet ved at tilføje known hosts med fingerprint-verificering. Stor sikkerhedsforbedring.
+
+**PR #182 – Nginx mount-sti** Config blev mounted til forkert sti (`conf.d/default.conf` i stedet for `nginx.conf`). Rettet i `docker-compose.prod.yml`.
+
+
+
+## Uenige i eller ignoreret
+
+**PR #89 – `.coderabbit.yaml` navngivning** CodeRabbit krævede at config-filen hedder `.coderabbit.yaml` i repo-roden. I stedet blev en workflow-fil oprettet under `.github/workflows/`. Filen eksisterer ikke i standardformat i dag.
+
+**PR #88 – Docker `latest`-tag** CodeRabbit anbefalede immutable image-tags i stedet for `:latest` for reproducible deploys og rollback-mulighed. `docker-compose.prod.yml` bruger stadig `:latest`. (`.dockerignore` med `*.db` ser dog ud til at være tilføjet et sted.)
+
+**PR #165 – Smoke test URL/port-konfiguration** Advarsler om CI smoke test URL og CD-workflow-konfiguration. Ingen commits der eksplicit adresserer det.
+
+**PR #102 – Dokumentation** Tomme sektioner og uafsluttet retrospektiv. Lavprioritets-cleanup der ser ud til at være udsat.
+
+
+
+## Mønster
+
+|                      | Antal PRs |
+| -------------------- | --------- |
+| Enige & rettet       | ~6        |
+| Uenige/ignoreret     | ~4        |
+| Delvis implementeret | ~3        |
+
+**Tendenser:** Sikkerhedsrelaterede fund (SSH, CSP, JSON-validering) tog I generelt seriøst. Konfigurationskonventioner (navngivning, image-tagging) afviste I. Dokumentationsforslag blev typisk udskudt.
+
+# bundler-audit
+
+bundler-audit tjekker `Gemfile.lock` mod kendte CVEs i Ruby-gems. Vi er enige i alle fund og har løbende opdateret afhængigheder, når sårbarheder er blevet opdaget. Vi har ikke ignoreret nogen fund fra dette tool.
+
+# Hadolint
+
+Hadolint linter vores Dockerfile og tjekker for best practices. Vi er enige i fundene og har rettet dem — herunder brug af non-root user og pinning af base images. Vi har ikke ignoreret nogen fund.
+
+# Trivy
+
+Trivy scanner Docker-imaget for kendte CVEs inden det pushes til GHCR. Vi har konfigureret det til kun at blokere ved `CRITICAL`-fund uden tilgængelig patch (`ignore-unfixed: true`). Dette er et bevidst valg: sårbarheder uden en tilgængelig rettelse kan vi ikke handle på, og non-critical fund vurderes acceptable for et projekt i denne skala.
+
+# OWASP ZAP
+
+OWASP ZAP kører en passiv baseline-scan mod den kørende applikation og rapporterer manglende sikkerhedsheaders og lignende. Vi er overordnet enige i fundene. Scanneren er konfigureret til ikke at fejle CI (`-I`), da den primært bruges til overblik. Vi har adresseret de mest kritiske headers og accepteret de resterende informationelle advarsler.
+
+# RuboCop
+Har opsnappet mange potentielle problemer i koden, og har været en uvurderlig hjælp til at holde koden ren og konsistent. Vi har aktivt lempet på nogle regler i konfigurationen (eks. metodelængde), da Ruby er et helt nyt programmeringssprog. 
+Det var en balancegang mellem at følge best practices og pragmatik, men set i bakspejlet (efter vi for sent introducerede SonarCloud) kan vi se, at vores kompleksitet er steget deraf. Det uddybes nærmere i afsnittet om SonarCloud.
+
+# SonarCloud 
 
 ## Cyklomatisk kompleksitet
 
@@ -31,3 +100,18 @@ Kognitiv kompleksitet måler, hvor svær koden er at læse og forstå — i mods
 Den høje score i `app.rb` skyldes primært at `POST /api/pages` har tre separate ansvar i én route: autentificering, validering og dataindsættelse. `before`/`after`-hooks og `track_user_activity` bidrager yderligere med nestede betingelser og rescue-blokke, der er vokset over tid.
 
 Den korrekte løsning ville være at udtrække disse ansvar i dedikerede service-objekter. Dette er blevet nedprioriteret til fordel for at levere features og infrastruktur inden for projektets tidsramme.
+
+
+# Konklusion
+
+**Er vi enige i fundene?**
+Overordnet ja. Fundene fra RuboCop, Brakeman, Hadolint og bundler-audit var legitime og handlede vi på. SonarClouds kompleksitetsmålinger er teknisk korrekte, men afspejler et bevidst arkitekturvalg snarere end sjusk. OWASP ZAPs og Trivys fund er acceptable for projektets skala.
+
+**Hvad har vi rettet?**
+Sikkerhedssårbarheder fra bundler-audit og Brakeman, Dockerfile-advarsler fra Hadolint, kodestilsproblemer fra RuboCop samt kritiske sikkerhedsfund fra CodeRabbit (SSH-fingerprinting, JSON-validering, CSP-headers).
+
+**Hvad har vi ignoreret?**
+Falske positive fra Brakeman, informationelle advarsler fra OWASP ZAP, non-critical og unfixable CVEs fra Trivy, nitpicks fra CodeRabbit samt den høje kompleksitet i `app.rb` og `function_app.py`.
+
+**Hvorfor?**
+Falske positive og informationelle advarsler kræver ikke handling. Kompleksiteten i `app.rb` var et bevidst valg om en flad struktur tilpasset applikationens størrelse — vi introducerede SonarCloud for sent til at en omstrukturering var realistisk inden for tidsrammen.

--- a/docs/software-quality/software-quality.md
+++ b/docs/software-quality/software-quality.md
@@ -3,9 +3,9 @@
 *Statisk sikkerhedsscanner til Ruby — analyserer kildekoden for SQL injection, XSS og lignende.*
 
 **Er vi enige i fundene?** Ja.
-**Hvad har vi rettet?** Alle legitime advarsler.
-**Hvad har vi ignoreret?** Falske positive omkring mass assignment og dynamiske queries.
-**Hvorfor?** Brakeman er kendt for falske positive i disse scenarier; vi vurderede dem ikke som reelle sårbarheder i vores kontekst.
+**Hvad har vi rettet?** Alle fund ved introduktionen af toolet.
+**Hvad har vi ignoreret?** Ingenting.
+**Hvorfor?** —
 
 # bundler-audit
 *Tjekker Gemfile.lock mod kendte CVEs i Ruby-gems.*

--- a/docs/software-quality/software-quality.md
+++ b/docs/software-quality/software-quality.md
@@ -1,7 +1,7 @@
 
 # Brakeman
 
-Brakeman er en statisk sikkerhedsscanner til Ruby, der analyserer kildekoden for kendte sårbarheder som SQL injection og XSS. Vi er enige i fundene og har rettet de legitime advarsler. Brakeman er kendt for at producere falske positive, særligt around mass assignment og dynamiske queries — disse har vi vurderet og bevidst ignoreret, da de ikke var reelle sårbarheder i vores kontekst.
+Brakeman er en statisk sikkerhedsscanner til Ruby, der analyserer kildekoden for kendte sårbarheder som SQL injection og XSS. Da vi introducerede dét tool, rettede vi kildekoden for at leve op til det sikkerhedsstandard.
 
 # CodeRabbit
 
@@ -56,7 +56,7 @@ bundler-audit tjekker `Gemfile.lock` mod kendte CVEs i Ruby-gems. Vi er enige i 
 
 # Hadolint
 
-Hadolint linter vores Dockerfile og tjekker for best practices. Vi er enige i fundene og har rettet dem — herunder brug af non-root user og pinning af base images. Vi har ikke ignoreret nogen fund.
+Hadolint linter vores Dockerfile og tjekker for best practices. Vi er enige i fundene og har rettet dem — herunder brug af non-root user. Hadolint anbefaler at pinne base images med et digest (f.eks. `ruby:3.2-slim@sha256:...`) for reproducible builds, men vi bruger stadig det flydende tag `ruby:3.2-slim`. Dette er et bevidst valg, da automatiske sikkerhedsopdateringer i base imaget vurderes vigtigere end strikt reproducerbarhed i dette projekt.
 
 # Trivy
 

--- a/docs/software-quality/software-quality.md
+++ b/docs/software-quality/software-quality.md
@@ -1,3 +1,22 @@
+
+
+
+## Cyklomatisk kompleksitet
+
+Cyklomatisk kompleksitet tæller antallet af uafhængige stier gennem koden — hver `if`, `elsif`, `case`, `while`, `&&` og `||` tilføjer 1.
+
+| Fil | Cyklomatisk kompleksitet |
+|-----|--------------------------|
+| `ruby-sinatra/app.rb` | 60 |
+| `azure-function/function_app.py` | 31 |
+| `ruby-sinatra/services/weather_service.rb` | 11 |
+| `scripts/migrate_sqlite_to_pg.rb` | 10 |
+| **Total** | **155** |
+
+Den høje score i `app.rb` skyldes primært at mange routes og forretningslogik er samlet ét sted — et klassisk Sinatra-mønster. Individuelle metoder holder sig under grænsen på 10-15, så kompleksiteten er fordelt frem for koncentreret.
+
+Opdeling i mindre controllers eller service-objekter ville reducere tallet, men er nedprioriteret inden for projektets tidsramme.
+
 ## Kognitiv kompleksitet
 
 Kognitiv kompleksitet måler, hvor svær koden er at læse og forstå — i modsætning til cyklomatisk kompleksitet straffer den dyb nesting hårdere end simpel forgrening.

--- a/docs/software-quality/software-quality.md
+++ b/docs/software-quality/software-quality.md
@@ -13,7 +13,7 @@ Cyklomatisk kompleksitet tæller antallet af uafhængige stier gennem koden — 
 | `scripts/migrate_sqlite_to_pg.rb` | 10 |
 | **Total** | **155** |
 
-Den høje score i `app.rb` skyldes primært at mange routes og forretningslogik er samlet ét sted — et klassisk Sinatra-mønster. Individuelle metoder holder sig under grænsen på 10-15, så kompleksiteten er fordelt frem for koncentreret.
+`POST /api/pages` illustrerer problemet: routen indeholder fem separate forgreningspunkter (autentificering, to valideringer, filtrering og duplikatfjernelse), der hver tilføjer en ny sti gennem koden. Det samlede tal for `app.rb` afspejler derudover at mange routes og forretningslogik er samlet ét sted — et klassisk Sinatra-mønster.
 
 Opdeling i mindre controllers eller service-objekter ville reducere tallet, men er nedprioriteret inden for projektets tidsramme.
 

--- a/docs/software-quality/software-quality.md
+++ b/docs/software-quality/software-quality.md
@@ -36,6 +36,8 @@ CodeRabbit gennemgår automatisk alle PRs og kommenterer på potentielle problem
 
 **PR #102 – Dokumentation** Tomme sektioner og uafsluttet retrospektiv. Lavprioritets-cleanup der ser ud til at være udsat.
 
+**Grafana eksponeret på offentlig IP** CodeRabbit anbefalede at binde Grafana til `127.0.0.1` og tilgå den via SSH-tunnel. Vi valgte bevidst at beholde den på `0.0.0.0:3000`, da SSH-tunnel tilføjer friktion for alle teammedlemmer i et kortlivet skoleprojekt. Grafana er sikret med krævet login, deaktiveret signup og deaktiveret anonym adgang. I et produktionsmiljø ville vi binde til localhost og placere en nginx reverse proxy med TLS foran.
+
 
 
 ## Mønster

--- a/docs/software-quality/software-quality.md
+++ b/docs/software-quality/software-quality.md
@@ -5,7 +5,7 @@
 **Er vi enige i fundene?** Ja.
 **Hvad har vi rettet?** Alle fund ved introduktionen af toolet.
 **Hvad har vi ignoreret?** Ingenting.
-**Hvorfor?** —
+**Hvorfor?** SQL injection og lignende sårbarheder i kildekoden er uacceptable — selv i et skoleprojekt.
 
 # bundler-audit
 *Tjekker Gemfile.lock mod kendte CVEs i Ruby-gems.*
@@ -13,7 +13,7 @@
 **Er vi enige i fundene?** Ja.
 **Hvad har vi rettet?** Alle fund.
 **Hvad har vi ignoreret?** Ingenting.
-**Hvorfor?** —
+**Hvorfor?** Kendte sårbarheder i afhængigheder er uacceptable — vi ønsker ikke at køre deprecated gems med kendte CVEs i produktion.
 
 # CodeRabbit
 *AI-drevet code review — kommenterer automatisk på alle PRs.*

--- a/docs/software-quality/software-quality.md
+++ b/docs/software-quality/software-quality.md
@@ -1,0 +1,14 @@
+## Kognitiv kompleksitet
+
+Kognitiv kompleksitet måler, hvor svær koden er at læse og forstå — i modsætning til cyklomatisk kompleksitet straffer den dyb nesting hårdere end simpel forgrening.
+
+| Fil | Kognitiv kompleksitet |
+|-----|----------------------|
+| `ruby-sinatra/app.rb` | 71 |
+| `azure-function/function_app.py` | 26 |
+| `scripts/migrate_sqlite_to_pg.rb` | 6 |
+| **Total** | **127** |
+
+Den høje score i `app.rb` skyldes primært at `POST /api/pages` har tre separate ansvar i én route: autentificering, validering og dataindsættelse. `before`/`after`-hooks og `track_user_activity` bidrager yderligere med nestede betingelser og rescue-blokke, der er vokset over tid.
+
+Den korrekte løsning ville være at udtrække disse ansvar i dedikerede service-objekter. Dette er blevet nedprioriteret til fordel for at levere features og infrastruktur inden for projektets tidsramme.

--- a/docs/software-quality/software-quality.md
+++ b/docs/software-quality/software-quality.md
@@ -66,6 +66,8 @@ Trivy scanner Docker-imaget for kendte CVEs inden det pushes til GHCR. Vi har ko
 
 OWASP ZAP kører en passiv baseline-scan mod den kørende applikation og rapporterer manglende sikkerhedsheaders og lignende. Vi er overordnet enige i fundene. Scanneren er konfigureret til ikke at fejle CI (`-I`), da den primært bruges til overblik. Vi har adresseret de mest kritiske headers og accepteret de resterende informationelle advarsler.
 
+CF-workflowet producerer følgende advarsel: `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02` kører på Node.js 20, som er deprecated i GitHub Actions og fjernes fra runneren den 16. september 2026. Vi ser bevidst bort fra dette, da projektsimulationen afsluttes inden da.
+
 # RuboCop
 Har opsnappet mange potentielle problemer i koden, og har været en uvurderlig hjælp til at holde koden ren og konsistent. Vi har aktivt lempet på nogle regler i konfigurationen (eks. metodelængde), da Ruby er et helt nyt programmeringssprog. 
 Det var en balancegang mellem at følge best practices og pragmatik, men set i bakspejlet (efter vi for sent introducerede SonarCloud) kan vi se, at vores kompleksitet er steget deraf. Det uddybes nærmere i afsnittet om SonarCloud.

--- a/docs/software-quality/software-quality.md
+++ b/docs/software-quality/software-quality.md
@@ -87,9 +87,9 @@
 *Analyserer teknisk gæld, kompleksitet og kodekvalitet på tværs af hele codebasen.*
 
 **Er vi enige i fundene?** Ja, målingerne er korrekte.
-**Hvad har vi rettet?** Ingenting — kompleksiteten er opstået gradvist over tid.
-**Hvad har vi ignoreret?** Cyklomatisk og kognitiv kompleksitet i `app.rb` og `function_app.py`.
-**Hvorfor?** Se nedenfor.
+**Hvad har vi rettet?** Ingenting.
+**Hvad har vi ignoreret?** Cyklomatisk og kognitiv kompleksitet i `app.rb`.
+**Hvorfor?** Vi introducerede SonarCloud på bagkant, og nåede derfor ikke at omstrukturere koden i separate service-objekter. Se nedenfor.
 
 ## Cyklomatisk kompleksitet
 
@@ -137,7 +137,7 @@ Overordnet ja. Fundene fra RuboCop, Brakeman, Hadolint og bundler-audit var legi
 Sikkerhedssårbarheder fra bundler-audit og Brakeman, Dockerfile-advarsler fra Hadolint, kodestilsproblemer fra RuboCop samt kritiske sikkerhedsfund fra CodeRabbit (SSH-fingerprinting, JSON-validering, CSP-headers).
 
 **Hvad har vi ignoreret?**
-Falske positive fra Brakeman, informationelle advarsler fra OWASP ZAP, non-critical og unfixable CVEs fra Trivy, nitpicks fra CodeRabbit samt den høje kompleksitet i `app.rb`.
+Informationelle advarsler fra OWASP ZAP, non-critical og unfixable CVEs fra Trivy, nitpicks fra CodeRabbit samt den høje kompleksitet i `app.rb`.
 
 **Hvorfor?**
 Falske positive og informationelle advarsler kræver ikke handling. Kompleksiteten i `app.rb` var et bevidst valg om en flad struktur tilpasset applikationens størrelse — vi introducerede SonarCloud for sent til at en omstrukturering var realistisk inden for tidsrammen.

--- a/docs/software-quality/software-quality.md
+++ b/docs/software-quality/software-quality.md
@@ -98,10 +98,9 @@ Cyklomatisk kompleksitet tæller antallet af uafhængige stier gennem koden — 
 | Fil | Cyklomatisk kompleksitet |
 |-----|--------------------------|
 | `ruby-sinatra/app.rb` | 60 |
-| `azure-function/function_app.py` | 31 |
 | `ruby-sinatra/services/weather_service.rb` | 11 |
 | `scripts/migrate_sqlite_to_pg.rb` | 10 |
-| **Total** | **155** |
+| **Total** | **81** |
 
 `POST /api/pages` illustrerer problemet: routen indeholder fem separate forgreningspunkter (autentificering, to valideringer, filtrering og duplikatfjernelse), der hver tilføjer en ny sti gennem koden. Det samlede tal for `app.rb` afspejler derudover at mange routes og forretningslogik er samlet ét sted — et klassisk Sinatra-mønster.
 
@@ -114,9 +113,8 @@ Kognitiv kompleksitet måler, hvor svær koden er at læse og forstå — i mods
 | Fil | Kognitiv kompleksitet |
 |-----|----------------------|
 | `ruby-sinatra/app.rb` | 71 |
-| `azure-function/function_app.py` | 26 |
 | `scripts/migrate_sqlite_to_pg.rb` | 6 |
-| **Total** | **127** |
+| **Total** | **77** |
 
 Den høje score i `app.rb` skyldes primært at `POST /api/pages` har tre separate ansvar i én route: autentificering, validering og dataindsættelse. `before`/`after`-hooks og `track_user_activity` bidrager yderligere med nestede betingelser og rescue-blokke, der er vokset over tid.
 
@@ -139,7 +137,7 @@ Overordnet ja. Fundene fra RuboCop, Brakeman, Hadolint og bundler-audit var legi
 Sikkerhedssårbarheder fra bundler-audit og Brakeman, Dockerfile-advarsler fra Hadolint, kodestilsproblemer fra RuboCop samt kritiske sikkerhedsfund fra CodeRabbit (SSH-fingerprinting, JSON-validering, CSP-headers).
 
 **Hvad har vi ignoreret?**
-Falske positive fra Brakeman, informationelle advarsler fra OWASP ZAP, non-critical og unfixable CVEs fra Trivy, nitpicks fra CodeRabbit samt den høje kompleksitet i `app.rb` og `function_app.py`.
+Falske positive fra Brakeman, informationelle advarsler fra OWASP ZAP, non-critical og unfixable CVEs fra Trivy, nitpicks fra CodeRabbit samt den høje kompleksitet i `app.rb`.
 
 **Hvorfor?**
 Falske positive og informationelle advarsler kræver ikke handling. Kompleksiteten i `app.rb` var et bevidst valg om en flad struktur tilpasset applikationens størrelse — vi introducerede SonarCloud for sent til at en omstrukturering var realistisk inden for tidsrammen.

--- a/docs/software-quality/software-quality.md
+++ b/docs/software-quality/software-quality.md
@@ -15,7 +15,7 @@ Cyklomatisk kompleksitet tæller antallet af uafhængige stier gennem koden — 
 
 `POST /api/pages` illustrerer problemet: routen indeholder fem separate forgreningspunkter (autentificering, to valideringer, filtrering og duplikatfjernelse), der hver tilføjer en ny sti gennem koden. Det samlede tal for `app.rb` afspejler derudover at mange routes og forretningslogik er samlet ét sted — et klassisk Sinatra-mønster.
 
-Opdeling i mindre controllers eller service-objekter ville reducere tallet, men er nedprioriteret inden for projektets tidsramme.
+Sinatra pålægger ingen struktur for opdeling af routes og forretningslogik — i modsætning til Rails, der tvinger én controller per resource. Vi valgte bevidst at samle al logik i `app.rb`, da applikationen var lille og en fladere struktur virkede passende. Vi blev opmærksomme på kompleksitetsmålingerne for sent i forløbet til at en større omstrukturering var realistisk.
 
 ## Kognitiv kompleksitet
 

--- a/docs/software-quality/software-quality.md
+++ b/docs/software-quality/software-quality.md
@@ -1,16 +1,29 @@
 
 # Brakeman
+*Statisk sikkerhedsscanner til Ruby — analyserer kildekoden for SQL injection, XSS og lignende.*
 
-Brakeman er en statisk sikkerhedsscanner til Ruby, der analyserer kildekoden for kendte sårbarheder som SQL injection og XSS. Da vi introducerede dét tool, rettede vi kildekoden for at leve op til det sikkerhedsstandard.
+**Er vi enige i fundene?** Ja.
+**Hvad har vi rettet?** Alle legitime advarsler.
+**Hvad har vi ignoreret?** Falske positive omkring mass assignment og dynamiske queries.
+**Hvorfor?** Brakeman er kendt for falske positive i disse scenarier; vi vurderede dem ikke som reelle sårbarheder i vores kontekst.
+
+# bundler-audit
+*Tjekker Gemfile.lock mod kendte CVEs i Ruby-gems.*
+
+**Er vi enige i fundene?** Ja.
+**Hvad har vi rettet?** Alle fund.
+**Hvad har vi ignoreret?** Ingenting.
+**Hvorfor?** —
 
 # CodeRabbit
+*AI-drevet code review — kommenterer automatisk på alle PRs.*
 
-CodeRabbit gennemgår automatisk alle PRs og kommenterer på potentielle problemer i koden. Vi er enige i størstedelen af fundene og har aktivt handlet på dem. Vi har ignoreret kommentarer, der omhandlede strukturen i Choices and Challenges.md samt nitpicks-kommentarer.
-
+**Er vi enige i fundene?** Størstedelen.
+**Hvad har vi rettet?** Sikkerhedsrelaterede fund: SSH-fingerprinting, JSON-validering, CSP-headers, Nginx mount-sti.
+**Hvad har vi ignoreret?** Nitpicks, dokumentationsforslag, konfigurationskonventioner og Grafana-eksponering.
+**Hvorfor?** Sikkerhedsfund prioriteres; konventioner og dokumentation er lavere prioritet inden for projektets tidsramme.
 
 **41 PRs** med CodeRabbit-aktivitet fundet (ca. 153 kode-kommentarer + 95 issue-kommentarer).
-
-
 
 ## Enige i og rettet
 
@@ -24,21 +37,17 @@ CodeRabbit gennemgår automatisk alle PRs og kommenterer på potentielle problem
 
 **PR #182 – Nginx mount-sti** Config blev mounted til forkert sti (`conf.d/default.conf` i stedet for `nginx.conf`). Rettet i `docker-compose.prod.yml`.
 
-
-
 ## Uenige i eller ignoreret
 
 **PR #89 – `.coderabbit.yaml` navngivning** CodeRabbit krævede at config-filen hedder `.coderabbit.yaml` i repo-roden. I stedet blev en workflow-fil oprettet under `.github/workflows/`. Filen eksisterer ikke i standardformat i dag.
 
-**PR #88 – Docker `latest`-tag** CodeRabbit anbefalede immutable image-tags i stedet for `:latest` for reproducible deploys og rollback-mulighed. `docker-compose.prod.yml` bruger stadig `:latest`. (`.dockerignore` med `*.db` ser dog ud til at være tilføjet et sted.)
+**PR #88 – Docker `latest`-tag** CodeRabbit anbefalede immutable image-tags i stedet for `:latest` for reproducible deploys og rollback-mulighed. `docker-compose.prod.yml` bruger stadig `:latest`.
 
 **PR #165 – Smoke test URL/port-konfiguration** Advarsler om CI smoke test URL og CD-workflow-konfiguration. Ingen commits der eksplicit adresserer det.
 
 **PR #102 – Dokumentation** Tomme sektioner og uafsluttet retrospektiv. Lavprioritets-cleanup der ser ud til at være udsat.
 
 **Grafana eksponeret på offentlig IP** CodeRabbit anbefalede at binde Grafana til `127.0.0.1` og tilgå den via SSH-tunnel. Vi valgte bevidst at beholde den på `0.0.0.0:3000`, da SSH-tunnel tilføjer friktion for alle teammedlemmer i et kortlivet skoleprojekt. Grafana er sikret med krævet login, deaktiveret signup og deaktiveret anonym adgang. I et produktionsmiljø ville vi binde til localhost og placere en nginx reverse proxy med TLS foran.
-
-
 
 ## Mønster
 
@@ -48,31 +57,39 @@ CodeRabbit gennemgår automatisk alle PRs og kommenterer på potentielle problem
 | Uenige/ignoreret     | ~4        |
 | Delvis implementeret | ~3        |
 
-**Tendenser:** Sikkerhedsrelaterede fund (SSH, CSP, JSON-validering) tog I generelt seriøst. Konfigurationskonventioner (navngivning, image-tagging) afviste I. Dokumentationsforslag blev typisk udskudt.
-
-# bundler-audit
-
-bundler-audit tjekker `Gemfile.lock` mod kendte CVEs i Ruby-gems. Vi er enige i alle fund og har løbende opdateret afhængigheder, når sårbarheder er blevet opdaget. Vi har ikke ignoreret nogen fund fra dette tool.
+**Tendenser:** Sikkerhedsrelaterede fund (SSH, CSP, JSON-validering) tog vi generelt seriøst. Konfigurationskonventioner (navngivning, image-tagging) afviste vi. Dokumentationsforslag blev typisk udskudt.
 
 # Hadolint
+*Linter til Dockerfile — tjekker for best practices.*
 
-Hadolint linter vores Dockerfile og tjekker for best practices. Vi er enige i fundene og har rettet dem — herunder brug af non-root user. Hadolint anbefaler at pinne base images med et digest (f.eks. `ruby:3.2-slim@sha256:...`) for reproducible builds, men vi bruger stadig det flydende tag `ruby:3.2-slim`. Dette er et bevidst valg, da automatiske sikkerhedsopdateringer i base imaget vurderes vigtigere end strikt reproducerbarhed i dette projekt.
-
-# Trivy
-
-Trivy scanner Docker-imaget for kendte CVEs inden det pushes til GHCR. Vi har konfigureret det til kun at blokere ved `CRITICAL`-fund uden tilgængelig patch (`ignore-unfixed: true`). Dette er et bevidst valg: sårbarheder uden en tilgængelig rettelse kan vi ikke handle på, og non-critical fund vurderes acceptable for et projekt i denne skala.
+**Er vi enige i fundene?** Ja.
+**Hvad har vi rettet?** Non-root user.
+**Hvad har vi ignoreret?** Pinning af base image med digest (`ruby:3.2-slim` er et flydende tag).
+**Hvorfor?** Automatiske sikkerhedsopdateringer i base imaget vurderes vigtigere end strikt reproducerbarhed i dette projekt.
 
 # OWASP ZAP
+*Passiv baseline-scan mod den kørende applikation — rapporterer runtime-sårbarheder og manglende sikkerhedsheaders.*
 
-OWASP ZAP kører en passiv baseline-scan mod den kørende applikation og rapporterer manglende sikkerhedsheaders og lignende. Vi er overordnet enige i fundene. Scanneren er konfigureret til ikke at fejle CI (`-I`), da den primært bruges til overblik. Vi har adresseret de mest kritiske headers og accepteret de resterende informationelle advarsler.
-
-CF-workflowet producerer følgende advarsel: `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02` kører på Node.js 20, som er deprecated i GitHub Actions og fjernes fra runneren den 16. september 2026. Vi ser bevidst bort fra dette, da projektsimulationen afsluttes inden da.
+**Er vi enige i fundene?** Overordnet ja.
+**Hvad har vi rettet?** Sikkerhedsheaders i nginx (HSTS, CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy).
+**Hvad har vi ignoreret?** Informationelle advarsler og Node.js 20 deprecation-advarsel i CF-workflowet.
+**Hvorfor?** Informationelle advarsler kræver ikke handling. CF-workflowet producerer følgende advarsel: `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02` kører på Node.js 20, som fjernes fra GitHub Actions den 16. september 2026. Vi ser bevidst bort fra dette, da projektsimulationen afsluttes inden da.
 
 # RuboCop
-Har opsnappet mange potentielle problemer i koden, og har været en uvurderlig hjælp til at holde koden ren og konsistent. Vi har aktivt lempet på nogle regler i konfigurationen (eks. metodelængde), da Ruby er et helt nyt programmeringssprog. 
-Det var en balancegang mellem at følge best practices og pragmatik, men set i bakspejlet (efter vi for sent introducerede SonarCloud) kan vi se, at vores kompleksitet er steget deraf. Det uddybes nærmere i afsnittet om SonarCloud.
+*Kodekvalitet og konsistens for Ruby — enforcer style guide og bedste praksisser.*
 
-# SonarCloud 
+**Er vi enige i fundene?** Ja.
+**Hvad har vi rettet?** Størstedelen af fund løbende.
+**Hvad har vi ignoreret?** Metodelængde-reglen, som vi har lempet i konfigurationen.
+**Hvorfor?** Ruby er et nyt sprog for teamet; pragmatiske lempelser var nødvendige. Set i bakspejlet bidrog det til øget kompleksitet — uddybes under SonarCloud.
+
+# SonarCloud
+*Analyserer teknisk gæld, kompleksitet og kodekvalitet på tværs af hele codebasen.*
+
+**Er vi enige i fundene?** Ja, målingerne er korrekte.
+**Hvad har vi rettet?** Ingenting — kompleksiteten er opstået gradvist over tid.
+**Hvad har vi ignoreret?** Cyklomatisk og kognitiv kompleksitet i `app.rb` og `function_app.py`.
+**Hvorfor?** Se nedenfor.
 
 ## Cyklomatisk kompleksitet
 
@@ -105,6 +122,13 @@ Den høje score i `app.rb` skyldes primært at `POST /api/pages` har tre separat
 
 Den korrekte løsning ville være at udtrække disse ansvar i dedikerede service-objekter. Dette er blevet nedprioriteret til fordel for at levere features og infrastruktur inden for projektets tidsramme.
 
+# Trivy
+*Scanner Docker-imaget for kendte CVEs inden push til GHCR.*
+
+**Er vi enige i fundene?** Ja.
+**Hvad har vi rettet?** Kritiske CVEs med tilgængelig patch.
+**Hvad har vi ignoreret?** Non-critical CVEs og CVEs uden tilgængelig patch.
+**Hvorfor?** Sårbarheder uden patch kan vi ikke handle på; non-critical fund vurderes acceptable for projektets skala.
 
 # Konklusion
 


### PR DESCRIPTION
## Summary
- Adds `software-quality.md` with reflections on all code quality tools used in CI
- Each tool answers: agree with findings, what was fixed, what was ignored, and why
- Tools covered: Brakeman, bundler-audit, CodeRabbit, Hadolint, OWASP ZAP, RuboCop, SonarCloud (cyclomatic + cognitive complexity), Trivy

## Test plan
- [x] Review document content for accuracy