### PR TITLE
test: tilføj contract test for GET /api/weather

### DIFF
--- a/ruby-sinatra/spec/integration/contract_spec.rb
+++ b/ruby-sinatra/spec/integration/contract_spec.rb
@@ -70,6 +70,17 @@ RSpec.describe 'OpenAPI Contract' do
     end
   end
 
+  describe 'GET /api/weather' do
+    it 'returns StandardResponse with data object' do
+      skip 'OPENWEATHER_API_KEY not set' unless ENV['OPENWEATHER_API_KEY']
+      get '/api/weather'
+      expect(last_response.status).to eq(200)
+      body = JSON.parse(last_response.body)
+      expect(body).to have_key('data')
+      expect(body['data']).to be_a(Hash)
+    end
+  end
+
   describe 'GET /api/search' do
     it 'returns 422 with statusCode and message when q is missing' do
       get '/api/search'

--- a/ruby-sinatra/spec/integration/contract_spec.rb
+++ b/ruby-sinatra/spec/integration/contract_spec.rb
@@ -71,8 +71,13 @@ RSpec.describe 'OpenAPI Contract' do
   end
 
   describe 'GET /api/weather' do
+    before do
+      allow(WeatherService).to receive(:fetch).and_return(
+        { city: 'Copenhagen', temperature: 12.0, condition: 'clear', humidity: 60, wind_speed: 5 }
+      )
+    end
+
     it 'returns StandardResponse with data object' do
-      skip 'OPENWEATHER_API_KEY not set' unless ENV['OPENWEATHER_API_KEY']
       get '/api/weather'
       expect(last_response.status).to eq(200)
       body = JSON.parse(last_response.body)


### PR DESCRIPTION
## Description
`GET /api/weather` var defineret i Anders' OpenAPI-spec men manglede en contract test. Testen er nu tilføjet med en deterministisk stub af `WeatherService` så den altid kører uafhængigt af `OPENWEATHER_API_KEY`.

## Related Issue
Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [ ] Documentation
- [ ] DevOps / Infrastructure
- [x] Chore

## Changes Made
- Tilføjet contract test for `GET /api/weather` der verificerer at response matcher `StandardResponse` schemaet (`{ data: Hash }`)
- Stubber `WeatherService.fetch` med fake-data så testen er deterministisk og ikke afhænger af eksternt API

## How to Test
1. `cd ruby-sinatra`
2. `bundle exec rspec spec/integration/contract_spec.rb --format documentation`
3. Verificer at `GET /api/weather` kører uden skip og består

## Checklist
- [x] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added contract test for the weather API endpoint to validate response structure and status verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->