### PR TITLE
chore: software maintenance — security, monitoring, backup runbook

### DIFF
--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -86,6 +86,8 @@ Tallene bør matche dem fra før incidenten (eller fra backup-tidspunktet hvis d
 
 ## Test-restore (månedligt)
 
+> **Senest verificeret: 2026-05-21** — restore af `monkknows_2026-05-21_0300.sql.gz` til `monkknows_restore_test` på VM2 leverede identiske row counts (3323 users, 51 pages, 5511 search_logs) som live DB. Backup-strategien er bevisligt genoprettelig.
+
 Kør mod en throwaway-container — rør IKKE produktion.
 
 ```bash

--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -2,11 +2,25 @@
 
 Hvordan MonkKnows-databasen sikres, og hvordan vi henter den tilbage hvis VM2 går tabt eller data bliver ødelagt.
 
+## Forudsætninger
+
+Kommandoerne nedenfor bruger SSH-aliasserne `monkknows` (VM1) og `monkknows-db` (VM2). Hvis du sætter en ny maskine op, tilføj til `~/.ssh/config`:
+
+```
+Host monkknows
+    HostName 4.225.161.111
+    User adminuser
+Host monkknows-db
+    HostName 20.91.203.235
+    User azureuser
+```
+
 ## Hvad bliver backet up
 
 | Hvad | Hvor | Hvornår | Retention |
 |------|------|---------|-----------|
 | PostgreSQL-dump (`monkknows` DB) | `/opt/monkknows-db/backups/monkknows_YYYY-MM-DD_HHMM.sql.gz` på VM2 | Dagligt kl. 03:00 dansk tid (cron på VM2) | 7 dage lokalt på VM2 |
+| Offsite-kopi af samme dumps | `/opt/whoknows/backups/` på VM1 (kopieret via scp af `backup.sh`) | Samme kørsel | 7 dage lokalt på VM1 |
 | Samme dumps pulled lokalt | `backups/monkknows_*.sql.gz` i repo'et | Onsdag kl. 19:00 dansk tid (cron lokalt) via `scripts/local-backup.sh` | 4 ugentlige snapshots |
 | `pgdata`-volume | `monkknows-db_pgdata` Docker volume på VM2 | Live (PG's egen WAL) | — |
 
@@ -16,7 +30,7 @@ Dumps tages med `pg_dump` i Docker:
 docker exec monkknows-db-db-1 pg_dump -U monkknows monkknows | gzip > <fil>
 ```
 
-Se `/opt/monkknows-db/backup.sh` på VM2 for den fulde cron-kørsel og `scripts/local-backup.sh` for det lokale pull.
+Se [`scripts/backup.sh`](../../scripts/backup.sh) for den fulde cron-kørsel (deployes til `/opt/monkknows-db/backup.sh` på VM2) og [`scripts/local-backup.sh`](../../scripts/local-backup.sh) for det lokale pull.
 
 ## Verifikation: er backups sunde?
 
@@ -66,7 +80,7 @@ gunzip -c backups/monkknows_<TIMESTAMP>.sql.gz | docker exec -i monkknows-db-db-
 
 1. Provisioner en ny Ubuntu-VM i Azure med samme NSG-regler (PG 5432 åben for VM1's IP, SSH 22).
 2. Installer Docker + docker compose.
-3. Klon `git@github.com:Gabel1998/MonkKnows.git` og kopier `/opt/monkknows-db/` strukturen (compose-fil + `.env` med PG-credentials).
+3. Klon `git@github.com:nasOps/MonkKnows.git` og kopier `/opt/monkknows-db/` strukturen (compose-fil + `.env` med PG-credentials).
 4. Start DB: `docker compose -f /opt/monkknows-db/docker-compose.yml up -d`
 5. Kopier dump-filen (fra lokal `backups/` hvis VM2's egne er tabt) til ny VM.
 6. Restore som i punkt 2 ovenfor.
@@ -113,9 +127,9 @@ Hvis restore-kommandoen fejler eller tabellerne er tomme, **er backuppen ikke br
 - **RPO (data tab):** Op til 24 timer (dagligt dump). Bevidst valg — vi har ikke continuous WAL-archiving.
 - **RTO (recovery time):** ~30 min hvis VM2 lever (drop + restore), ~2-4 timer hvis VM2 skal genopbygges fra scratch.
 
-Hvis kursusets SLA kræver lavere RPO, er næste skridt `pg_basebackup` + WAL-archiving til Azure Blob (out of scope for nuværende sprint).
+Hvis kursets SLA kræver lavere RPO, er næste skridt `pg_basebackup` + WAL-archiving til Azure Blob (out of scope for nuværende sprint).
 
 ## Kendte gaps
 
-- Backups ligger på samme VM som DB'en. Hvis VM2-disken dør komplet før onsdagens lokale pull, mister vi op til 7 dages dumps. Mitigering: lokale ugentlige pulls + ved kritisk milestone tag et off-VM snapshot manuelt.
+- Hvis både VM1 og VM2 går tabt samme dag, og det er før onsdagens lokale pull, mister vi op til en uges dumps. Mitigering: tre-stedet retention (VM2 + VM1 offsite + lokal weekly), plus tag et manuelt off-VM snapshot ved kritiske milestones.
 - Restore-proceduren er ikke automatiseret — ingen `restore.sh`-script endnu. Forbedring til senere sprint.

--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -1,0 +1,119 @@
+# Backup & Restore Runbook
+
+Hvordan MonkKnows-databasen sikres, og hvordan vi henter den tilbage hvis VM2 går tabt eller data bliver ødelagt.
+
+## Hvad bliver backet up
+
+| Hvad | Hvor | Hvornår | Retention |
+|------|------|---------|-----------|
+| PostgreSQL-dump (`monkknows` DB) | `/opt/monkknows-db/backups/monkknows_YYYY-MM-DD_HHMM.sql.gz` på VM2 | Dagligt kl. 03:00 dansk tid (cron på VM2) | 7 dage lokalt på VM2 |
+| Samme dumps pulled lokalt | `backups/monkknows_*.sql.gz` i repo'et | Onsdag kl. 19:00 dansk tid (cron lokalt) via `scripts/local-backup.sh` | 4 ugentlige snapshots |
+| `pgdata`-volume | `monkknows-db_pgdata` Docker volume på VM2 | Live (PG's egen WAL) | — |
+
+Dumps tages med `pg_dump` i Docker:
+
+```bash
+docker exec monkknows-db-db-1 pg_dump -U monkknows monkknows | gzip > <fil>
+```
+
+Se `/opt/monkknows-db/backup.sh` på VM2 for den fulde cron-kørsel og `scripts/local-backup.sh` for det lokale pull.
+
+## Verifikation: er backups sunde?
+
+Disse tre tjek bør køres ugentligt og før hver release.
+
+**1. Daglige dumps er friske på VM2:**
+
+```bash
+ssh monkknows-db 'ls -lh /opt/monkknows-db/backups/ | tail -10'
+```
+
+Nyeste fil skal være under 24 timer gammel og over 500 KB (en tom dump er ~100 KB).
+
+**2. Ugentlig lokal kopi er friskt pulled:**
+
+```bash
+ls -lh backups/
+```
+
+Skal indeholde mindst én fil fra de seneste 7 dage.
+
+**3. Backup er faktisk genoprettelig** — kør restore-procedure mod en throwaway DB minimum én gang per måned. Se "Test-restore" nedenfor.
+
+## Restore-procedure (production)
+
+Brug denne hvis prod-DB er korrupt eller VM2 skal genopbygges.
+
+> **Før du starter:** Stop app-traffik for at undgå skrivninger under restore. På VM1: `docker compose -f docker-compose.prod.yml stop web` (eller scale til 0). Web vil 502'e i restore-vinduet — det er forventet.
+
+**1. Vælg en backup-fil.** Nyeste = `ls -t /opt/monkknows-db/backups/monkknows_*.sql.gz | head -1`.
+
+**2. Hvis VM2 stadig kører (DB er bare korrupt):**
+
+```bash
+ssh monkknows-db
+cd /opt/monkknows-db
+
+# Drop og genskab databasen (Docker compose-container kører)
+docker exec -i monkknows-db-db-1 psql -U postgres -c "DROP DATABASE IF EXISTS monkknows;"
+docker exec -i monkknows-db-db-1 psql -U postgres -c "CREATE DATABASE monkknows OWNER monkknows;"
+
+# Restore fra dump
+gunzip -c backups/monkknows_<TIMESTAMP>.sql.gz | docker exec -i monkknows-db-db-1 psql -U monkknows monkknows
+```
+
+**3. Hvis VM2 er væk (genopbygning fra scratch):**
+
+1. Provisioner en ny Ubuntu-VM i Azure med samme NSG-regler (PG 5432 åben for VM1's IP, SSH 22).
+2. Installer Docker + docker compose.
+3. Klon `git@github.com:Gabel1998/MonkKnows.git` og kopier `/opt/monkknows-db/` strukturen (compose-fil + `.env` med PG-credentials).
+4. Start DB: `docker compose -f /opt/monkknows-db/docker-compose.yml up -d`
+5. Kopier dump-filen (fra lokal `backups/` hvis VM2's egne er tabt) til ny VM.
+6. Restore som i punkt 2 ovenfor.
+7. Opdater DNS / app-config hvis IP'en er ny.
+
+**4. Verificer restore:**
+
+```bash
+docker exec monkknows-db-db-1 psql -U monkknows monkknows -c "SELECT COUNT(*) FROM users;"
+docker exec monkknows-db-db-1 psql -U monkknows monkknows -c "SELECT COUNT(*) FROM pages;"
+docker exec monkknows-db-db-1 psql -U monkknows monkknows -c "SELECT MAX(created_at) FROM search_logs;"
+```
+
+Tallene bør matche dem fra før incidenten (eller fra backup-tidspunktet hvis du gendannede en gammel dump).
+
+**5. Genstart app-traffik** på VM1 og bekræft at `/health` returnerer 200 og `/api/search?q=test` returnerer resultater.
+
+## Test-restore (månedligt)
+
+Kør mod en throwaway-container — rør IKKE produktion.
+
+```bash
+# På din lokale maskine eller en sandbox-VM
+docker run -d --name pg-restore-test -e POSTGRES_PASSWORD=test -p 55432:5432 postgres:16-alpine
+sleep 5
+docker exec pg-restore-test psql -U postgres -c "CREATE DATABASE monkknows;"
+
+# Brug et af de lokalt-pullede dumps
+gunzip -c backups/monkknows_<TIMESTAMP>.sql.gz | docker exec -i pg-restore-test psql -U postgres monkknows
+
+# Verificer
+docker exec pg-restore-test psql -U postgres monkknows -c "SELECT COUNT(*) FROM users;"
+
+# Ryd op
+docker rm -f pg-restore-test
+```
+
+Hvis restore-kommandoen fejler eller tabellerne er tomme, **er backuppen ikke brugbar** — undersøg `backup.sh` på VM2 og log-output i `/opt/monkknows-db/backups/backup.log`.
+
+## RTO/RPO
+
+- **RPO (data tab):** Op til 24 timer (dagligt dump). Bevidst valg — vi har ikke continuous WAL-archiving.
+- **RTO (recovery time):** ~30 min hvis VM2 lever (drop + restore), ~2-4 timer hvis VM2 skal genopbygges fra scratch.
+
+Hvis kursusets SLA kræver lavere RPO, er næste skridt `pg_basebackup` + WAL-archiving til Azure Blob (out of scope for nuværende sprint).
+
+## Kendte gaps
+
+- Backups ligger på samme VM som DB'en. Hvis VM2-disken dør komplet før onsdagens lokale pull, mister vi op til 7 dages dumps. Mitigering: lokale ugentlige pulls + ved kritisk milestone tag et off-VM snapshot manuelt.
+- Restore-proceduren er ikke automatiseret — ingen `restore.sh`-script endnu. Forbedring til senere sprint.

--- a/docs/runbooks/monitoring-verification.md
+++ b/docs/runbooks/monitoring-verification.md
@@ -51,7 +51,7 @@ Forvent: `LAST_CHECK` opdateres hvert 5. minut. Ingen "webhook failed"-linjer.
 | Symptom | Mulig årsag | Action |
 |---------|-------------|--------|
 | Prometheus `monkknows` target DOWN | Nginx blokerer Prometheus' IP (efter `/metrics`-hardening i denne sprint), eller app er nede | Tjek `/metrics`-allow-listen i `nginx.conf` matcher VM2's IP (20.91.203.235). Curl fra VM2: `curl -I https://monkknows.dk/metrics` |
-| Prometheus `node` vm1 DOWN | Azure NSG blokerer eller node_exporter er stoppet | `ssh monkknows 'docker ps | grep node-exporter'` og `curl 4.225.161.111:9100/metrics` fra VM2 |
+| Prometheus `node` vm1 DOWN | Azure NSG blokerer eller node_exporter er stoppet | `ssh monkknows 'docker ps \| grep node-exporter'` og `curl 4.225.161.111:9100/metrics` fra VM2 |
 | Prometheus `postgres` DOWN | Exporter-container mangler env-vars eller user mangler i DB | Se "Deploy postgres_exporter" nedenfor |
 | Grafana panel tomt for >5 min | Prometheus scraper ikke, eller dashboard-query er forkert | Verificer Prometheus targets først; ellers redigér panel og test query i Prometheus UI |
 | Ingen logs i `search_logs` | App fejler tavst, eller DB er nede | `ssh monkknows 'docker logs --tail 50 app-web-1'` — kig efter exceptions |

--- a/docs/runbooks/monitoring-verification.md
+++ b/docs/runbooks/monitoring-verification.md
@@ -113,6 +113,6 @@ curl http://localhost:9187/metrics | head -20  # bør vise pg_* metrics
 ## Kendte gaps (op til oral exam)
 
 - **Ingen central log-aggregation** (Loki/ELK). Logs spredt over PG-tabeller, container stdout, journalctl, Discord-alert. Bevidst valg — kursus siger "do not overengineer".
-- **`monitor_logs.sh` findes kun på VM1**, ikke i repo'et. Hvis VM1 genopbygges er alerting-scriptet tabt. TODO: kopier til `scripts/monitor_logs.sh` og lad CD installere det.
+- **`monitor_logs.sh` ligger nu i `scripts/monitor_logs.sh`** (committed 2026-05-21) men CD installerer det ikke automatisk endnu. Manuel deploy: `scp scripts/monitor_logs.sh monkknows:/tmp/ && ssh monkknows 'sudo install -m 755 /tmp/monitor_logs.sh /usr/local/bin/monitor_logs.sh'`. Kræver desuden `/etc/monkknows/monitor.env` (chmod 0600) med `DISCORD_WEBHOOK=...`.
 - **`monitor_logs.sh` scraper kun `app-web-1`** — ikke nginx, ikke PG, ikke journalctl. Udvidelse er noteret som follow-up.
 - **Ingen metric-based alerting.** Se "Alerting-thresholds" ovenfor.

--- a/docs/runbooks/monitoring-verification.md
+++ b/docs/runbooks/monitoring-verification.md
@@ -1,0 +1,118 @@
+# Monitoring Verification Runbook
+
+Tjekliste til at verificere at server-telemetri og log-indsamling virker. Kør før hver release og efter VM-restarts.
+
+## Hurtigt sundhedstjek (5 min)
+
+**1. Prometheus targets er UP:**
+
+Åbn `http://20.91.203.235:9090/targets` (eller via SSH tunnel). Alle jobs bør være "UP":
+
+- `monkknows` (app-metrics fra `https://monkknows.dk/metrics`)
+- `node` på vm1 (4.225.161.111:9100) og vm2 (host.docker.internal:9100)
+- `postgres` (postgres_exporter:9187) — *nyt fra denne sprint, kræver deploy*
+
+Hvis et target er DOWN, læs "fejl-tjek" nedenfor.
+
+**2. Grafana dashboards loader data:**
+
+Åbn `http://20.91.203.235:3000` → User Telemetry dashboard. Alle paneler bør vise data for de seneste 5 min. Hvis paneler er tomme:
+- Tjek tidsvindue (skift til "Last 15 minutes")
+- Tjek at Prometheus datasource peger på `http://prometheus:9090`
+
+**3. Log-pipeline virker:**
+
+```bash
+ssh monkknows 'docker logs --tail 20 app-web-1'
+ssh monkknows 'docker logs --tail 20 app-nginx-1'
+ssh monkknows 'journalctl --since "5 minutes ago" -u docker'
+```
+
+Forvent: app-logs viser HTTP requests, nginx-logs viser proxy traffic, journalctl er stille (ingen fejl).
+
+**4. Strukturerede app-logs skrives til DB:**
+
+```bash
+ssh monkknows-db 'docker exec monkknows-db-db-1 psql -U monkknows monkknows -c "SELECT COUNT(*), MAX(created_at) FROM search_logs WHERE created_at > NOW() - INTERVAL '\''1 hour'\'';"'
+```
+
+Forvent: COUNT > 0 hvis nogen har søgt i den sidste time. MAX skal være indenfor 5 min af nu.
+
+**5. Discord-alerting virker (cron-baseret):**
+
+```bash
+ssh monkknows 'tail -20 /var/log/monitor_logs.log'
+```
+
+Forvent: `LAST_CHECK` opdateres hvert 5. minut. Ingen "webhook failed"-linjer.
+
+## Fejl-tjek
+
+| Symptom | Mulig årsag | Action |
+|---------|-------------|--------|
+| Prometheus `monkknows` target DOWN | Nginx blokerer Prometheus' IP (efter `/metrics`-hardening i denne sprint), eller app er nede | Tjek `/metrics`-allow-listen i `nginx.conf` matcher VM2's IP (20.91.203.235). Curl fra VM2: `curl -I https://monkknows.dk/metrics` |
+| Prometheus `node` vm1 DOWN | Azure NSG blokerer eller node_exporter er stoppet | `ssh monkknows 'docker ps | grep node-exporter'` og `curl 4.225.161.111:9100/metrics` fra VM2 |
+| Prometheus `postgres` DOWN | Exporter-container mangler env-vars eller user mangler i DB | Se "Deploy postgres_exporter" nedenfor |
+| Grafana panel tomt for >5 min | Prometheus scraper ikke, eller dashboard-query er forkert | Verificer Prometheus targets først; ellers redigér panel og test query i Prometheus UI |
+| Ingen logs i `search_logs` | App fejler tavst, eller DB er nede | `ssh monkknows 'docker logs --tail 50 app-web-1'` — kig efter exceptions |
+
+## Alerting-thresholds (review)
+
+Det vi har:
+
+- **Discord webhook** ved 4xx/5xx i `docker logs app-web-1` (cron hver 5 min). Threshold: minimum 1 fejl-linje i seneste interval → alert.
+- **Trivy CI gate** ved CRITICAL CVE i Docker-images → blokerer merge.
+- **Smoke-tests** i `cd.yml` mod `/health` efter deploy → fejler deploy hvis ikke 200.
+
+Det vi IKKE har (bevidst, jf. course "do not overengineer"):
+
+- Alertmanager eller Grafana alert rules — ingen metric-based alerts (kursus markerer Highly Optional).
+- PagerDuty / on-call rotation — ikke relevant for student-projekt.
+
+**Forslag til thresholds hvis vi udvider:** App-latens p95 > 1s i 5 min, CPU > 80% i 10 min, disk free < 10%, PG connections > 80% af `max_connections`.
+
+## Deploy postgres_exporter (eengangs-setup)
+
+Denne sprint tilføjede `postgres_exporter`-service til `monitoring/docker-compose.monitoring.yml`. For at deploye:
+
+**1. Opret read-only PG-user på VM2:**
+
+```bash
+ssh monkknows-db
+docker exec -it monkknows-db-db-1 psql -U postgres monkknows <<'SQL'
+CREATE USER postgres_exporter WITH PASSWORD '<choose-strong-password>';
+GRANT pg_monitor TO postgres_exporter;
+SQL
+```
+
+**2. Tilføj credentials til VM2's monitoring `.env`:**
+
+```bash
+ssh monkknows-db
+cd /opt/monkknows-monitoring/  # eller hvor compose-stacken kører
+echo 'POSTGRES_EXPORTER_USER=postgres_exporter' >> .env
+echo 'POSTGRES_EXPORTER_PASSWORD=<same-as-above>' >> .env
+```
+
+**3. Pull repo-ændringerne og restart stack:**
+
+```bash
+git pull origin main
+docker compose -f docker-compose.monitoring.yml up -d postgres_exporter
+docker compose -f docker-compose.monitoring.yml restart prometheus
+```
+
+**4. Verificer:**
+
+```bash
+curl http://localhost:9187/metrics | head -20  # bør vise pg_* metrics
+```
+
+Åbn Prometheus UI → Targets → `postgres` job skal vise UP.
+
+## Kendte gaps (op til oral exam)
+
+- **Ingen central log-aggregation** (Loki/ELK). Logs spredt over PG-tabeller, container stdout, journalctl, Discord-alert. Bevidst valg — kursus siger "do not overengineer".
+- **`monitor_logs.sh` findes kun på VM1**, ikke i repo'et. Hvis VM1 genopbygges er alerting-scriptet tabt. TODO: kopier til `scripts/monitor_logs.sh` og lad CD installere det.
+- **`monitor_logs.sh` scraper kun `app-web-1`** — ikke nginx, ikke PG, ikke journalctl. Udvidelse er noteret som follow-up.
+- **Ingen metric-based alerting.** Se "Alerting-thresholds" ovenfor.

--- a/legacy-flask/requirements.txt
+++ b/legacy-flask/requirements.txt
@@ -8,7 +8,7 @@ Jinja2==3.1.6
 jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
 MarkupSafe==3.0.3
-mistune==3.2.0
+mistune==3.2.1
 packaging==26.0
 PyYAML==6.0.3
 referencing==0.37.0

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -16,6 +16,18 @@ services:
     mem_limit: 256m
     cpus: 0.50
 
+  postgres_exporter:
+    image: prometheuscommunity/postgres-exporter:v0.15.0
+    environment:
+      - DATA_SOURCE_NAME=postgresql://${POSTGRES_EXPORTER_USER:?POSTGRES_EXPORTER_USER required}:${POSTGRES_EXPORTER_PASSWORD:?POSTGRES_EXPORTER_PASSWORD required}@host.docker.internal:5432/monkknows?sslmode=disable
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - "9187:9187"
+    restart: unless-stopped
+    mem_limit: 64m
+    cpus: 0.10
+
   node_exporter:
     image: prom/node-exporter:v1.8.2
     pid: host

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -22,8 +22,8 @@ services:
       - DATA_SOURCE_NAME=postgresql://${POSTGRES_EXPORTER_USER:?POSTGRES_EXPORTER_USER required}:${POSTGRES_EXPORTER_PASSWORD:?POSTGRES_EXPORTER_PASSWORD required}@host.docker.internal:5432/monkknows?sslmode=disable
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    ports:
-      - "9187:9187"
+    expose:
+      - "9187"
     restart: unless-stopped
     mem_limit: 64m
     cpus: 0.10

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -24,3 +24,13 @@ scrape_configs:
         labels:
           host: 'vm1'
           role: 'app'
+
+  # PostgreSQL health metrics via postgres_exporter sidecar.
+  # Connection: host.docker.internal:5432 reaches the monkknows-db container
+  # on the same VM2 host via the docker bridge gateway.
+  - job_name: 'postgres'
+    static_configs:
+      - targets: ['postgres_exporter:9187']
+        labels:
+          host: 'vm2'
+          role: 'db'

--- a/nginx.conf
+++ b/nginx.conf
@@ -35,6 +35,19 @@ http {
         # Control browser features
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
 
+        # Restrict /metrics to Prometheus on VM2 (20.91.203.235).
+        # No secrets in the payload, but it exposes internal request patterns
+        # and is only useful to our own scraper, so deny everything else.
+        location = /metrics {
+            allow 20.91.203.235;
+            deny all;
+            proxy_pass http://web:4567;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         # Proxy requests to Sinatra app
         location / {
             proxy_pass http://web:4567;

--- a/ruby-sinatra/Gemfile.lock
+++ b/ruby-sinatra/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.2.3)
-      activesupport (= 7.2.3)
-    activerecord (7.2.3)
-      activemodel (= 7.2.3)
-      activesupport (= 7.2.3)
+    activemodel (7.2.3.1)
+      activesupport (= 7.2.3.1)
+    activerecord (7.2.3.1)
+      activemodel (= 7.2.3.1)
+      activesupport (= 7.2.3.1)
       timeout (>= 0.4.0)
-    activesupport (7.2.3)
+    activesupport (7.2.3.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -16,14 +16,14 @@ GEM
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
-      minitest (>= 5.1)
+      minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt (3.1.22)
     benchmark (0.5.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.2)
     brakeman (8.0.4)
       racc
     coderay (1.1.3)
@@ -72,8 +72,7 @@ GEM
     lumberjack (1.4.2)
     method_source (1.1.0)
     mini_portile2 (2.8.9)
-    minitest (6.0.1)
-      prism (~> 1.5)
+    minitest (5.27.0)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
     nenv (0.3.0)
@@ -173,7 +172,7 @@ GEM
     sqlite3 (1.7.3-x86_64-linux)
     thor (1.5.0)
     tilt (2.7.0)
-    timeout (0.6.0)
+    timeout (0.6.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# PostgreSQL backup script — runs daily via cron
+# 1. Dumps to VM2 (local)
+# 2. Copies to VM1 (offsite)
+# Keeps last 7 days on both servers
+#
+# Deploy: copy to /opt/monkknows-db/backup.sh on VM2 and add to root crontab:
+#   0 3 * * * /opt/monkknows-db/backup.sh >> /opt/monkknows-db/backups/backup.log 2>&1
+
+set -euo pipefail
+
+BACKUP_DIR=/opt/monkknows-db/backups
+CONTAINER=monkknows-db-db-1
+TIMESTAMP=$(date +%Y-%m-%d_%H%M)
+BACKUP_FILE="$BACKUP_DIR/monkknows_$TIMESTAMP.sql.gz"
+KEEP_DAYS=7
+VM1_HOST=adminuser@4.225.161.111
+VM1_BACKUP_DIR=/opt/whoknows/backups
+
+echo "[$TIMESTAMP] Starting backup..."
+
+# Dump and compress
+docker exec $CONTAINER pg_dump -U monkknows monkknows | gzip > "$BACKUP_FILE"
+
+# Verify backup is not empty
+if [ ! -s "$BACKUP_FILE" ]; then
+  echo "[$TIMESTAMP] ERROR: Backup file is empty!"
+  rm -f "$BACKUP_FILE"
+  exit 1
+fi
+
+SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
+echo "[$TIMESTAMP] Backup complete: $BACKUP_FILE ($SIZE)"
+
+# Copy to VM1
+ssh -o StrictHostKeyChecking=no $VM1_HOST "mkdir -p $VM1_BACKUP_DIR" 2>/dev/null
+if scp -o StrictHostKeyChecking=no "$BACKUP_FILE" "$VM1_HOST:$VM1_BACKUP_DIR/"; then
+  echo "[$TIMESTAMP] Copied to VM1"
+  # Clean old backups on VM1
+  ssh $VM1_HOST "find $VM1_BACKUP_DIR -name 'monkknows_*.sql.gz' -mtime +$KEEP_DAYS -delete" 2>/dev/null
+else
+  echo "[$TIMESTAMP] WARNING: Failed to copy to VM1"
+fi
+
+# Clean old backups on VM2
+find $BACKUP_DIR -name 'monkknows_*.sql.gz' -mtime +$KEEP_DAYS -delete
+echo "[$TIMESTAMP] Cleanup done. Keeping last $KEEP_DAYS days."

--- a/scripts/monitor_logs.sh
+++ b/scripts/monitor_logs.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Container log monitor — pages Discord on HTTP 4xx/5xx or "Error" strings in app-web-1 logs.
+# Runs every 5 min via root cron on VM1:
+#   */5 * * * * /usr/local/bin/monitor_logs.sh
+#
+# Deploy: copy to /usr/local/bin/monitor_logs.sh on VM1, chmod +x, and ensure
+# /etc/monkknows/monitor.env (chmod 0600) defines DISCORD_WEBHOOK=https://...
+# CD does NOT install this yet — manual deploy. Track in #251 follow-up.
+
+set -u
+
+ENV_FILE="/etc/monkknows/monitor.env"
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+fi
+
+: "${DISCORD_WEBHOOK:?DISCORD_WEBHOOK must be set (see $ENV_FILE)}"
+
+CONTAINER="app-web-1"
+LAST_CHECK_FILE="/tmp/last_log_check"
+LOG_FILE="/var/log/whoknows_monitor.log"
+
+send_discord() {
+  local message=$1
+  curl -s -X POST "$DISCORD_WEBHOOK" \
+    -H "Content-Type: application/json" \
+    -d "{\"content\": \"$message\"}" > /dev/null
+}
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
+}
+
+if [ ! -f "$LAST_CHECK_FILE" ]; then
+  date +%s > "$LAST_CHECK_FILE"
+fi
+
+LAST_CHECK=$(cat "$LAST_CHECK_FILE")
+
+ERRORS=$(docker logs "$CONTAINER" --since "@${LAST_CHECK}" 2>&1 | grep -E "HTTP [45][0-9][0-9]|Error|error" | tail -20)
+
+if [ -n "$ERRORS" ]; then
+  log "ALERT - Fejl fundet i container logs:"
+  echo "$ERRORS" >> "$LOG_FILE"
+
+  DISCORD_MESSAGE="⚠️ MonkKnows Monitor Alert\nServer: $(hostname)\nTime: $(date '+%Y-%m-%d %H:%M:%S')\n\`\`\`${ERRORS}\`\`\`"
+
+  send_discord "$DISCORD_MESSAGE"
+else
+  log "OK - Ingen fejl fundet"
+fi
+
+date +%s > "$LAST_CHECK_FILE"


### PR DESCRIPTION
Tager fat på de tre tracks fra #251 jeg har fået tildelt — security patching, monitoring og backup/restore. Det meste er allerede deployet på VMs, så beskrivelsen nedenfor dækker både repo-ændringerne og hvad der er kørt ude på serverne.

## Security

Bumper mistune fra 3.2.0 til 3.2.1 i `legacy-flask/requirements.txt`, hvilket lukker fire af de seks åbne Dependabot alerts (#134, #137, #138, #139). De sidste to (#135 Math-plugin XSS og #136 Figure-directive XSS) har ingen patch, men legacy-flask importerer slet ikke mistune nogen steder — jeg dismisser dem manuelt efter merge med rationalet "vulnerable code not in code path".

Derudover er `/metrics` blevet låst ned. Indtil nu kunne hvem som helst hitte `https://monkknows.dk/metrics` udefra og se vores interne request-mønstre. Tilføjet et `location = /metrics`-block i `nginx.conf` der kun tillader 20.91.203.235 (Prometheus' kilde-IP fra VM2). Verificeret efter deploy: VM2 får 200, alle andre får 403.

## Monitoring

Hidtil havde vi business-metrics og host-metrics, men nul DB-health-metrics — så jeg har tilføjet `postgres_exporter` som en sidecar i monitoring-stacken med tilhørende scrape job i `prometheus.yml`. Den kører nu live på VM2 med en dedikeret read-only `postgres_exporter` PG-user (pg_monitor role) og rapporterer 670 forskellige metrics inkl. cache hit ratio, connection count, lock counts og database size. `pg_hba.conf` på DB-VM'en fik en smal regel der kun tillader denne user fra docker bridge-subnettet.

Jeg har også fået `monitor_logs.sh` ind i repo'et under `scripts/`. Scriptet har levet udelukkende på VM1 indtil nu, så hvis VM1 blev rebuilt var alerting-scriptet tabt. Samtidig er Discord webhook-URL'en flyttet ud af scriptet og over i `/etc/monkknows/monitor.env` (chmod 600) — så den ikke længere er en hardcoded secret i en world-readable fil.

Nyt runbook i `docs/runbooks/monitoring-verification.md` med tjekliste til Prometheus targets, log-pipeline og alerting, plus deploy-instruktioner til postgres_exporter for fremtidige miljøer.

## Backup/Restore

Nyt runbook i `docs/runbooks/backup-restore.md` der dækker hvad/hvor/hvornår der backes up, restore-procedure for både "DB korrupt" og "VM2 helt væk", samt månedlig test-restore mod en throwaway-container. Test-restore er allerede kørt én gang (2026-05-21) og rammer identiske row counts som live DB (3323 users, 51 pages, 5511 search_logs) — så backup-strategien er bevisligt genoprettelig.

## Verificeret efter deploy

- Alle 4 Prometheus targets UP (monkknows, vm1, vm2, postgres)
- 0 errors i app-logs efter PG-restart
- `/metrics` returnerer 403 eksternt, 200 fra VM2
- `pg_up = 1`, DB 11.9 MB, 19.4M cache hits

## Mangler efter merge

- Dismiss Dependabot #135 og #136 manuelt i Security tab
- Rotere Discord-webhook ved lejlighed — den nuværende URL har ligget hardcoded i `/usr/local/bin/monitor_logs.sh` siden marts