### PR TITLE
fix: patch CVE-2026-42258 — pin net-imap >= 0.5.7 i Gemfile

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,6 +65,7 @@ jobs:
           exit-code: '1'
           severity: CRITICAL
           ignore-unfixed: 'true'
+          trivyignores: ruby-sinatra/.trivyignore
 
       # Push the same scanned image — no rebuild
       - name: Push Docker image to GHCR

--- a/docs/choices-and-challenges/Choices and Challenges.md
+++ b/docs/choices-and-challenges/Choices and Challenges.md
@@ -2943,3 +2943,46 @@ Vi rollbacker ikke v2.0.0 → v1.3.0. Tagget er pushed, deployet er kørt grønt
 - "Vi har gjort meget arbejde" er ikke et semver-argument. Mængden af PRs siden sidste tag siger intet om hvorvidt API-kontrakten er ændret.
 - Den rigtige måde at versionere er at lade OpenAPI-specen være primær sandhedskilde: bump version når specen ændres bagudkompatibelt (MINOR) eller bryder (MAJOR), bug-fixes ellers. Det er en strammere kobling end milestone-tagging og giver versionsnummeret reel betydning.
 - Forced password reset (#222) burde have været vores første post-v1.0.0 MAJOR. At det blev bundlet ind i v1.3.0 viser hvor let det er at tabe semver-disciplin når man tænker i sprints frem for kontrakter.
+
+------
+
+## Trivy CRITICAL CVE i stdlib-gem — pin frem for ignore
+
+### Context
+
+CD-pipelinen bruger Trivy til at scanne Docker-imaget inden det pushes til GHCR (`severity: CRITICAL`, `ignore-unfixed: true`). Base-imaget `ruby:3.2-slim` shipper en version af `net-imap` (Ruby standard library gem) der er sårbar over for CVE-2026-42258 (CRITICAL). Fordi `ignore-unfixed: true` allerede er sat, betyder fejlen at en patch eksisterer — Trivy rapporterer kun fixable CVE'er.
+
+### Challenge
+
+Der er tre måder at håndtere en sårbar stdlib-gem på:
+
+1. **Opgrader base-imaget** — Skift til en nyere patch af `ruby:3.2-slim` der shipper en opdateret `net-imap`. Problemet er at vi ikke kontrollerer hvornår det officielle image opdateres, og vi kan ikke garantere at en nyere tag er tilgængelig i `3.2`-linjen.
+2. **Tilføj CVE til `.trivyignore`** — Supprimerer fejlen uden at løse den. Hvis `ignore-unfixed: true` er sat burde vi aldrig ignorere en CVE der HAR en fix. Det ville underminere hele formålet med scanningen.
+3. **Pin gem'et eksplicit i Gemfile** — Overskriver stdlib-versionen ved at tvinge Bundler til at installere en nyere, patchet version. Løser problemet ved kilden.
+
+### Choice
+
+**Beslutning: Pin `net-imap >= 0.5.7` i Gemfile. Bundler resolver til 0.6.4 (seneste stabile).**
+
+Gem-pin er den eneste løsning der faktisk fjerner sårbarheden frem for at skjule den. Bundler installerer den patchede version i imaget under build-steget, så Trivy scanner den nye version.
+
+Som belt-and-suspenders oprettes desuden `ruby-sinatra/.trivyignore` med CVE-entry'en **kommenteret ud**. Filen tjener to formål: den dokumenterer hændelsen og giver en hurtig fallback hvis gem-pin mod forventning ikke propagerer til det scannede image-lag. `trivyignores`-parameteren er tilføjet til Trivy-steget i `cd.yml` så filen faktisk bruges hvis den aktiveres.
+
+**Fordele:**
+
+- Sårbarheden er fjernet, ikke suppresseret — scanningen har reel værdi
+- Gem-pin er synlig i Gemfile og Gemfile.lock — reviewers kan se hvad der er overskrevet og hvorfor
+- `.trivyignore`-templaten med udløbsdato-format giver en struktureret håndtering af fremtidige edge cases
+- `ignore-unfixed: true` bevarer sin semantiske integritet
+
+**Ulemper:**
+
+- Eksplicit pin på en stdlib-gem er en unaturlig afhængighed — fremtidige udviklere kan undre sig over hvorfor `net-imap` er i Gemfile
+- Vi kører nu på `net-imap 0.6.4` som er nyere end Ruby 3.2's bundlede version — minor risiko for API-uoverensstemmelser hvis vi nogensinde bruger IMAP direkte (vi gør ikke)
+- Gem-pinnet skal opdateres eller fjernes hvis Ruby 3.2-linjen begynder at shippe en patchet stdlib-version
+
+**Læring:**
+
+- `ignore-unfixed: true` i Trivy er ikke en undskyldning for at ignorere CVE'er — det er et filter der fjerner støj fra CVE'er uden tilgængelig fix. Når Trivy stadig rapporterer en CVE med det flag sat, eksisterer der en løsning.
+- Stdlib-gems i Ruby er ikke immutable — de kan overskrives via Gemfile ligesom tredjepartsgems. Det er en ikke-åbenlys egenskab ved Bundler der er værd at kende.
+- `.trivyignore` bør have udløbsdatoer. En ignore-entry uden dato er en teknisk gæld der vokser usynligt.

--- a/ruby-sinatra/.trivyignore
+++ b/ruby-sinatra/.trivyignore
@@ -1,0 +1,9 @@
+# Trivy ignore file — only use for CVEs where no fix is available yet.
+# Always set an expiry date so ignores don't silently outlive their reason.
+# Format: CVE-ID exp:YYYY-MM-DD
+
+# CVE-2026-42258 is patched by pinning net-imap >= 0.5.7 in Gemfile (see commit).
+# This entry is a belt-and-suspenders fallback in case the pin does not propagate
+# into the scanned image layer. Remove once CD has been verified green.
+# exp:2026-08-01
+# CVE-2026-42258

--- a/ruby-sinatra/Gemfile
+++ b/ruby-sinatra/Gemfile
@@ -5,8 +5,8 @@ source 'https://rubygems.org'
 gem 'activerecord', '~> 7.0'
 gem 'bcrypt', '~> 3.1'
 gem 'digest' # To hash IP addresses for logging unique users
-gem 'net-imap', '>= 0.5.7' # Pinned to override ruby:3.2-slim stdlib version — patches CVE-2026-42258
 gem 'dotenv'
+gem 'net-imap', '>= 0.5.7' # Pinned to override ruby:3.2-slim stdlib version — patches CVE-2026-42258
 # ostruct is no longer part of default gems from Ruby 4.0
 # so we include it explicitly to avoid warnings
 gem 'ostruct'

--- a/ruby-sinatra/Gemfile
+++ b/ruby-sinatra/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gem 'activerecord', '~> 7.0'
 gem 'bcrypt', '~> 3.1'
 gem 'digest' # To hash IP addresses for logging unique users
+gem 'net-imap', '>= 0.5.7' # Pinned to override ruby:3.2-slim stdlib version — patches CVE-2026-42258
 gem 'dotenv'
 # ostruct is no longer part of default gems from Ruby 4.0
 # so we include it explicitly to avoid warnings

--- a/ruby-sinatra/Gemfile.lock
+++ b/ruby-sinatra/Gemfile.lock
@@ -33,6 +33,7 @@ GEM
       rack (>= 1.5)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
+    date (3.5.1)
     diff-lcs (1.6.2)
     digest (3.2.1)
     docile (1.4.1)
@@ -76,6 +77,11 @@ GEM
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
     nenv (0.3.0)
+    net-imap (0.6.4)
+      date
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
     nio4r (2.7.5)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -194,6 +200,7 @@ DEPENDENCIES
   dotenv
   guard
   guard-shell
+  net-imap (>= 0.5.7)
   ostruct
   pg (~> 1.5)
   prometheus-client (~> 4.0)


### PR DESCRIPTION
## Description

CD-pipelinen var blokeret af Trivy CRITICAL-scan pga. CVE-2026-42258 i `net-imap` (Ruby stdlib bundlet i `ruby:3.2-slim`). Løsningen er at overskrive stdlib-versionen ved at pinne gem'et eksplicit i Gemfile.

## Related Issue
Closes #300
Ref #251 (Bug Fixing @hajisan)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [ ] Documentation
- [ ] DevOps / Infrastructure
- [ ] Chore

## Changes Made
- `ruby-sinatra/Gemfile`: tilføjet `gem 'net-imap', '>= 0.5.7'` — Bundler resolver til 0.6.4
- `ruby-sinatra/Gemfile.lock`: opdateret med net-imap 0.6.4
- `ruby-sinatra/.trivyignore`: oprettet som dokumenteret fallback-template (CVE-entry kommenteret ud)
- `.github/workflows/cd.yml`: tilføjet `trivyignores: ruby-sinatra/.trivyignore` til Trivy-steget
- `docs/choices-and-challenges/Choices and Challenges.md`: ADR for beslutningen om pin frem for ignore

## How to Test
1. Merge PR og observer at `deliver`-jobbet i CD passerer Trivy-scan
2. Verificér at `net-imap 0.6.4` fremgår af Gemfile.lock
3. Kør `bundle exec rspec` lokalt — ingen tests bør påvirkes (net-imap bruges ikke direkte i appen)

## Checklist
- [x] Tested locally
- [x] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [x] Database migrations work (if applicable)