### PR TITLE
docs: opdater README, ADRs og inline kommentarer + opret .github org-repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # MonkKnows
 
 ###### Sinatra Ruby
-[![Ruby CI (Build & Test)](https://github.com/nasOps/MonkKnows/actions/workflows/ci.yaml/badge.svg?branch=development)](https://github.com/nasOps/MonkKnows/actions/workflows/ci.yaml) ![Ruby](https://img.shields.io/badge/ruby-3.2.8-red) ![Contributors](https://img.shields.io/github/contributors/nasOps/MonkKnows) ![Open Issues](https://img.shields.io/github/issues/nasOps/MonkKnows?label=Open%20Issues) ![Last Commit](https://img.shields.io/github/last-commit/nasOps/MonkKnows)
+[![Ruby CI (Build & Test)](https://github.com/nasOps/MonkKnows/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/nasOps/MonkKnows/actions/workflows/ci.yml) ![Ruby](https://img.shields.io/badge/ruby-3.2.3-red) ![Contributors](https://img.shields.io/github/contributors/nasOps/MonkKnows) ![Open Issues](https://img.shields.io/github/issues/nasOps/MonkKnows?label=Open%20Issues) ![Last Commit](https://img.shields.io/github/last-commit/nasOps/MonkKnows)
 
 ###### Flask Python (Legacy)
 ![Python](https://img.shields.io/badge/python-3.14-blue) ![Flask](https://img.shields.io/badge/flask-3.1.2-blue)
 
-A search engine originally built in 2009, currently being migrated from Flask (Python) to Sinatra (Ruby) as part of a DevOps project.
-
-
+A search engine originally built in 2009, migrated from Flask (Python) to Sinatra (Ruby) as a DevOps course project. Live at **[monkknows.dk](https://monkknows.dk)**.
 
 ---
 
@@ -18,39 +16,64 @@ MonkKnows/
 ├── .github/
 │   ├── ISSUE_TEMPLATE/
 │   └── workflows/
-│       └── ci.yaml
+│       ├── ci.yml               # CI: lint, audit, test, smoke, e2e
+│       ├── cd.yml               # CD: build → Trivy scan → push GHCR → deploy → smoke test
+│       └── cd-monitoring.yml    # Deploy Prometheus + Grafana to monitoring VM
 ├── docs/
 │   ├── branching-strategi/
-│   ├── choices-and-challenges/
-│   └── openapi/
-├── legacy-flask/           # Python legacy application
-├── ruby-sinatra/           # Active Ruby/Sinatra application
-└── .gitignore
+│   ├── choices-and-challenges/  # ADR-log — alle væsentlige tekniske beslutninger
+│   ├── openapi/
+│   │   └── whoknows-spec.json   # API contract (source of truth — Anders)
+│   ├── runbooks/
+│   └── specs/
+│       └── ruby-sinatra-spec.json   # Implementation artifact — documents our extensions beyond the contract
+├── legacy-flask/                # Python/Flask legacy application
+│   └── generated-flasgger-spec.json
+├── monitoring/                  # Prometheus + Grafana config
+│   ├── docker-compose.monitoring.yml
+│   └── prometheus.yml
+├── ruby-sinatra/                # Active Ruby/Sinatra application
+├── scripts/                     # Ops scripts (backup, migration, hooks)
+├── docker-compose.dev.yml       # PostgreSQL + app + Guard hot-reload
+├── docker-compose.prod.yml      # Production: GHCR image + Nginx
+└── nginx.conf                   # Reverse proxy, TLS, security headers
 ```
 
 ---
 
-## Migration Strategy
+## Stack
 
-Flask and Sinatra run side by side during migration. Functionality is moved route by route – read-only endpoints first, authentication and write logic later. Both versions share the same SQLite database in the interim.
+| Layer | Technology |
+|---|---|
+| Application | Ruby 3.2.3, Sinatra ~> 4.0, Puma |
+| Database | PostgreSQL 16 (primary) + SQLite (search logging) |
+| Auth | bcrypt ~> 3.1 |
+| Observability | Prometheus + Grafana |
+| Infra | Docker, Nginx, Azure VMs |
+| CI/CD | GitHub Actions (`ci.yml` + `cd.yml`) |
 
 ---
 
 ## Setup
 
-### Ruby / Sinatra
+### Docker (recommended)
+```bash
+docker compose -f docker-compose.dev.yml up
+```
+
+App runs on `http://localhost:4567` with hot-reload via Guard.
+
+### Local (Ruby)
 ```bash
 cd ruby-sinatra
 bundle config set --local path vendor/bundle
 bundle install
-bundle exec ruby app.rb
+bundle exec rackup config.ru -p 4567
 ```
-
-App runs on `http://localhost:4567`
 
 ### Python / Flask (Legacy)
 ```bash
-cd python-legacy
+cd legacy-flask
 python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
@@ -58,3 +81,26 @@ python app.py
 ```
 
 App runs on `http://localhost:5000`
+
+---
+
+## CI/CD
+
+**CI** (`ci.yml`) runs on every push/PR to `main`:
+- Bundler Audit (CVE scan), Brakeman (static analysis), Hadolint (Dockerfile lint)
+- RSpec with SimpleCov (60% min coverage), Docker smoke test, Playwright E2E
+
+**CD** (`cd.yml`) runs on push to `main`:
+1. Build Docker image → Trivy vulnerability scan → push to GHCR
+2. SSH deploy to production VM → `docker compose up --wait`
+3. Smoke test against `https://monkknows.dk`
+
+---
+
+## Production
+
+Live at **https://monkknows.dk** on Azure (Ubuntu 22.04).
+
+Two VMs:
+- **App VM** — Nginx + Sinatra container (`ghcr.io/nasops/monkknows:latest`)
+- **Monitoring VM** — Prometheus, Grafana, PostgreSQL 16

--- a/docs/choices-and-challenges/Choices and Challenges.md
+++ b/docs/choices-and-challenges/Choices and Challenges.md
@@ -2357,13 +2357,13 @@ Sofies logging-system bruger en separat SQLite-database via `LoggingBase`. Ved c
 
 AAAAA!-gruppen gennemgik sitet og identificerede adskillige WCAG 2.1 Level AA-overtrædelser. Da projektet kører under Anders' simulator, som automatisk klikker på sitet og er afhængig af specifikke HTML-IDs (`id="search-input"`, `id="nav-login"` m.fl.), måtte rettelser ikke bryde disse kontrakter.
 
-## Session-cookies virker ikke bag nginx SSL-terminering
+### Challenge
 
 Rette de kritiske tilgængelighedsfejl uden at ændre i den eksisterende HTML-struktur (IDs, class-navne, `name`-attributter, JavaScript-funktionsnavne) — og uden at tilføje nye routes eller backend-logik.
 
 Et særligt opmærksomhedspunkt var den custom language-dropdown, som er implementeret med `<button>` + `<ul>` i stedet for et native `<select>` (arvet fra Flask-versionen). Et sådant custom widget kræver ARIA-attributter for at være tilgængeligt for screen readers.
 
-Anders' simulator rapporterede daglige `e2e_error:can_log_in`-fejl: simulatoren kunne logge ind (200 OK fra `/api/login`) men fandt aldrig `#nav-logout`-linket på `/` efterfølgende — dvs. sessionen gik tabt mellem login-kaldet og næste sideload.
+### Choice
 
 14 problemer rettet (10 i initial PR, 4 efter code review):
 
@@ -2992,3 +2992,53 @@ Der er fire måder at håndtere en sårbar stdlib-gem på:
 - **Iterativ debugging kræver præcis log-analyse** — hver iteration afslørede et nyt lag. CD-loggens konkrete sti (`net-imap-0.3.9.gemspec` vs. `net-imap-0.6.4.gemspec`) var afgørende for at forstå problemet.
 - **Trivy detekterer via gemspecs, ikke gem-kode** — det er muligt at fjerne gemspec'en uden at fjerne den underliggende gem-kode. Dette er kirurgisk men kræver at man forstår Trivys scanningsmekanisme.
 - `ignore-unfixed: true` i Trivy er ikke en undskyldning for at ignorere CVE'er — det er et filter der fjerner støj fra CVE'er uden tilgængelig fix. Når Trivy stadig rapporterer en CVE med det flag sat, eksisterer der en løsning.
+
+------
+
+## OpenAPI-specs — fra tre filer til én aktiv kontrakt
+
+### Context
+
+Under migrationens forløb opbyggede vi tre OpenAPI-specifikationsfiler i `docs/openapi/`:
+
+- `whoknows-spec.json` — Anders' originale spec, source of truth for kursuskontrakten (OpenAPI 3.0.0)
+- `ruby-sinatra-spec.json` — vores manuelt skrevne spec, løbende opdateret under udviklingen af Sinatra-appen (OpenAPI 3.1.0)
+- `generated-flasgger-spec.json` — auto-genereret fra Python/Flask legacy-koden via Flasgger
+
+`ruby-sinatra-spec.json` tjente som arbejdsdokument: vi sammenlignede løbende vores implementation mod `whoknows-spec.json` for at sikre kontraktoverholdelse. Den indeholder bevidste udvidelser ud over Anders' spec — bl.a. mere præcise response descriptions og ekstra query parameters på `GET /`.
+
+Vores contract tests (`spec/integration/contract_spec.rb`) kørte fra starten udelukkende mod `whoknows-spec.json` via `committee`-gem'et.
+
+### Challenge
+
+Da Ruby-appen var færdig og kontrakten verificeret, stod vi med tre filer der beskrev det samme API på tre forskellige måder. Det skabte to problemer:
+
+1. **Vedligeholdelsesforpligtelse:** Fremtidige ændringer i API'et kræver opdatering af `ruby-sinatra-spec.json` for at holde den i sync — men da den ikke bruges af tests, vil den uundgåeligt rotte.
+2. **Falsk tryghed:** Tilstedeværelsen af en Ruby-specifik spec i `docs/openapi/` signalerede at den var autoritativ, men tests validerede kun mod `whoknows-spec.json`. En fremtidig udvikler kunne nemt opdatere den forkerte fil.
+
+Omvendt indeholder `ruby-sinatra-spec.json` signalværdi: den viser at vi ikke blot opfyldte kontrakten, men aktivt forbedrede den med mere præcis dokumentation.
+
+### Choice
+
+**Beslutning:** Reorganiser spec-filerne efter rolle frem for oprydning ved sletning.
+
+- `generated-flasgger-spec.json` flyttes til `legacy-flask/` — den tilhører legacy-kodebasen og har ingen rolle i den aktive API-kontrakt.
+- `ruby-sinatra-spec.json` flyttes til `docs/specs/` som et historisk artefakt — den dokumenterer hvad vi rent faktisk byggede og de bevidste forbedringer af kontrakten, men fjernes fra `docs/openapi/` for at undgå forvirring om hvad der validerer.
+- `docs/openapi/` indeholder herefter kun `whoknows-spec.json` — én fil, én kontrakt, ingen tvetydighed.
+
+**Fordele:**
+
+- `docs/openapi/` har nu kun én fil — det er klart for enhver ny udvikler hvad der er source of truth.
+- `ruby-sinatra-spec.json` bevares som artefakt og kan bruges til at vise eksaminator at vi overgik minimumskontrakten.
+- `generated-flasgger-spec.json` er logisk placeret tæt på den kodebase den stammer fra.
+
+**Ulemper:**
+
+- `ruby-sinatra-spec.json` er ikke længere synligt knyttet til den aktive app — en læser af `docs/specs/` skal kende baggrunden for at forstå filen.
+- Ingen automatiseret garanti for at artefaktet holder trit med virkeligheden over tid.
+
+**Læring:**
+
+- Spec-filer der ikke bruges af tests rotter hurtigere end kode — de mangler den feedback-loop der tvinger opdateringer.
+- Formålet med en fil bør fremgå af dens placering, ikke kun af dens indhold. At flytte filer er billigere end at forklare undtagelser i dokumentation.
+- Tre specs til samme API er et tegn på at migrationens arbejdsproces ikke var eksplicit nok om hvornår arbejdsdokumenter skifter til artefakter eller udgår.

--- a/ruby-sinatra/app.rb
+++ b/ruby-sinatra/app.rb
@@ -4,7 +4,6 @@
 
 # Main application file - Routes + Controllers (combined)
 require 'sinatra'
-# require 'sinatra/activerecord'
 require 'json'
 require 'digest'
 require_relative 'config/environment'
@@ -17,8 +16,6 @@ require_relative 'models/search_log'
 require 'dotenv/load' if ENV['RACK_ENV'] != 'production'
 require 'prometheus/client'
 
-# TODO: Change class name to MonkKnowsApp
-# App is defined as modular Sinatra class
 class WhoknowsApp < Sinatra::Base
   register Sinatra::ActiveRecordExtension
 
@@ -181,7 +178,6 @@ class WhoknowsApp < Sinatra::Base
     query = params[:q].to_s.strip
     query = nil if query.empty?
 
-    # Saves the logging from search queries (from routes "/" and "/api/search") to PG
     if query && ['/', '/api/search'].include?(request.path_info)
       SEARCH_RESULT_COUNT.observe(@result_count) if @result_count
       begin
@@ -333,8 +329,6 @@ class WhoknowsApp < Sinatra::Base
 
   # POST /api/register - User registration
   # OpenAPI: operationId "register_api_register_post"
-  # POST /api/register - opretter en ny bruger
-  # Flask-akvivalent: app.py linje 143-165
   post '/api/register' do
     content_type :json
 
@@ -361,7 +355,6 @@ class WhoknowsApp < Sinatra::Base
       session[:user_id] = user.id
       @current_user = user
       track_user_activity
-      # Like Flask's "You were successfully registered..."
       status 200
       { statusCode: 200, message: 'You were successfully registered' }.to_json
     else
@@ -391,7 +384,6 @@ class WhoknowsApp < Sinatra::Base
       }.to_json
     end
 
-    # Gem bruger-id i session - svarer til Flask's session['user_id'] = user['id']
     session[:user_id] = user.id
     @current_user = user
     track_user_activity

--- a/ruby-sinatra/models/user.rb
+++ b/ruby-sinatra/models/user.rb
@@ -6,7 +6,6 @@ require 'digest'
 # User-model - mapper til 'users'-tabellen via ActiveRecord.
 # ActiveRecord finder automatisk tabellen ud fra klassenavnet (User => users).
 class User < ActiveRecord::Base
-  # Validations - svarer til if/elsif-tjek i Flask's /api/register route
   validates :username, presence: { message: 'You have to enter a username' },
                        uniqueness: { message: 'The username is already taken' }
 


### PR DESCRIPTION
## Summary

- Opdaterer README til nuværende tilstand: CI-badge, Ruby-version, mappestruktur, stack-tabel, setup-kommandoer, CI/CD-sektion og production-URL
- Fjerner forældede inline kommentarer i `app.rb` og `user.rb`: stale TODO, Flask-referencer, dead commented-out require, fejlagtig "to PG"-kommentar
- Retter manglende `### Challenge`/`### Choice`-overskrifter i Accessibility-sektionen i Choices & Challenges (fejlagtig session-cookie-overskrift var sat ind i stedet)
- Tilføjer manglende ADR: "OpenAPI-specs — fra tre filer til én aktiv kontrakt" (PR #298 fik den ikke med pga. merge-konflikt)
- Opretter [`nasOps/.github`](https://github.com/nasOps/.github) med org-profil og community health files: `profile/README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`

Closes #299

## Test plan

- [ ] CI grøn (RuboCop + RSpec)
- [ ] README-badge peger på korrekt workflow og branch
- [ ] `profile/README.md` vises på [github.com/nasOps](https://github.com/nasOps)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed repository documentation with CI/CD workflows, infrastructure specifications, and production deployment details
  * Expanded setup instructions to include Docker-based and local development options
  * Clarified technical decision documentation for accessibility and API contract management

* **Chores**
  * Removed internal code comments and docstrings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nasOps/MonkKnows/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->