### PR TITLE
chore: fix OWASP ZAP findings and add CI coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,14 @@ jobs:
       - name: Run tests
         run: bundle exec rspec
 
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: coverage-report
+          path: ruby-sinatra/coverage/
+          retention-days: 30
+
   # --- Smoke test (depends on build-test) ---
 
   smoke-test:

--- a/docs/tools/tools.md
+++ b/docs/tools/tools.md
@@ -1,0 +1,29 @@
+# Tools
+
+## CI — Continuous Integration
+
+| Tool | What it measures |
+|---|---|
+| **RuboCop** | Code style and complexity (including metrics cops) |
+| **Brakeman** | Static security analysis of Ruby code |
+| **Bundler Audit** | Known vulnerabilities in gem dependencies |
+| **Hadolint** | Dockerfile best practices |
+| **SonarCloud** | Code quality, duplication, complexity, and security |
+| **RSpec** | Unit and integration tests |
+| **Playwright** | End-to-end tests |
+
+## CF — Continuous Feedback
+
+| Tool | What it measures |
+|---|---|
+| **OWASP ZAP** | Dynamic security scanning of the running application |
+
+## CD — Continuous Delivery & Deployment
+
+| Tool | What it does |
+|---|---|
+| **Docker Buildx** | Builds the Docker image |
+| **Trivy** | Scans the Docker image for vulnerabilities |
+| **GHCR** | Stores and distributes the Docker image |
+| **SSH** | Deploys the image to the production server |
+| **Smoke Test** | Verifies the production URL is healthy after deployment |

--- a/nginx.conf
+++ b/nginx.conf
@@ -41,6 +41,15 @@ http {
         # Control browser features
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
 
+        # Prevent cross-origin documents from loading resources that don't grant permission
+        add_header Cross-Origin-Embedder-Policy "require-corp" always;
+
+        # Prevent cross-origin windows from sharing a browsing context
+        add_header Cross-Origin-Opener-Policy "same-origin" always;
+
+        # Restrict resource sharing to same origin
+        add_header Cross-Origin-Resource-Policy "same-origin" always;
+
         # Restrict /metrics to Prometheus on VM2 (20.91.203.235).
         # No secrets in the payload, but it exposes internal request patterns
         # and is only useful to our own scraper, so deny everything else.


### PR DESCRIPTION
## Description
Addresses findings from OWASP ZAP security scan and improves CI pipeline with coverage reporting.

## Related Issue
Closes #

## Type of Change
- [x] DevOps / Infrastructure
- [x] Chore

## Changes Made
- Add missing Cross-Origin security headers to `nginx.conf` (COEP, COOP, CORP)
- Add SimpleCov HTML coverage report upload as CI artifact
- Add tools overview documentation in `docs/tools/tools.md`

## How to Test
1. Merge and verify CI passes
2. Check GitHub Actions artifacts for `coverage-report` after CI run
3. Verify security headers are present on production via `curl -I https://monkknows.dk`

## Checklist
- [x] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)