### PR TITLE
fix: tillad registrering uden password2 (422-fejl mod simulator)

### DIFF
--- a/ruby-sinatra/app.rb
+++ b/ruby-sinatra/app.rb
@@ -335,9 +335,8 @@ class WhoknowsApp < Sinatra::Base
     password  = params[:password]
     password2 = params[:password2]
 
-    # Tjek password-match foerst (ikke en model-validation,
-    # da password2 ikke er en kolonne i databasen)
-    if password != password2
+    # Tjek password-match kun hvis password2 er sendt med (optional per OpenAPI spec)
+    if password2 && !password2.empty? && password != password2
       status 422
       return {
         detail: [{ loc: %w[body password2], msg: 'The two passwords do not match', type: 'value_error' }]

--- a/ruby-sinatra/spec/integration/app_spec.rb
+++ b/ruby-sinatra/spec/integration/app_spec.rb
@@ -71,6 +71,14 @@ RSpec.describe 'Whoknows App' do
       expect(last_response.status).to eq(200)
     end
 
+    it 'returns 200 when password2 is omitted in JSON payload' do
+      payload = valid_params.except(:password2).merge(username: 'jsonuser', email: 'json@example.com')
+      post '/api/register', payload.to_json, { 'CONTENT_TYPE' => 'application/json' }
+      expect(last_response.status).to eq(200)
+      body = JSON.parse(last_response.body)
+      expect(body['message']).to eq('You were successfully registered')
+    end
+
     it 'returns 422 when passwords do not match' do
       post '/api/register', valid_params.merge(password2: 'wrongpass')
       expect(last_response.status).to eq(422)

--- a/ruby-sinatra/spec/integration/app_spec.rb
+++ b/ruby-sinatra/spec/integration/app_spec.rb
@@ -66,6 +66,11 @@ RSpec.describe 'Whoknows App' do
       expect(body['message']).to eq('You were successfully registered')
     end
 
+    it 'returns 200 when password2 is omitted (optional per OpenAPI spec)' do
+      post '/api/register', valid_params.except(:password2)
+      expect(last_response.status).to eq(200)
+    end
+
     it 'returns 422 when passwords do not match' do
       post '/api/register', valid_params.merge(password2: 'wrongpass')
       expect(last_response.status).to eq(422)


### PR DESCRIPTION
## Description

Simulatoren (`nasOps` på Anders' plotserver) har genereret ~100+ fejl siden 2026-05-26 mod `/api/register`. Alle fejl havde samme signatur:

```json
[65146, "nasOps", "2026-05-31 19:37:54", "https://monkknows.dk", "/api/register",
  "RequestException",
  "Both JSON and form-encoded requests failed: 422 Client Error: Unprocessable Content for url: https://monkknows.dk/api/register"
]
```

Simulatoren forsøger både JSON og form-encoded — begge slog fejl med 422.

## Rodårsag

`password2` er markeret som **optional** i OpenAPI-spec (`Body_register_api_register_post`):

```json
"required": ["username", "email", "password"]
```

Simulatoren sender derfor ikke `password2`. Men vores app sammenlignede ubetinget:

```ruby
if password != password2   # password2 == nil → altid true → altid 422
```

## Fix

Checket kører nu kun når `password2` faktisk er sendt med og ikke-tom:

```ruby
if password2 && !password2.empty? && password != password2
```

## Related Issue

Closes #

## Type of Change
- [x] Bug fix

## Changes Made
- `ruby-sinatra/app.rb`: password2-validering er nu conditional (kun når feltet er til stede)
- `ruby-sinatra/spec/integration/app_spec.rb`: ny test `returns 200 when password2 is omitted`

## How to Test
1. `POST /api/register` med `username`, `email`, `password` — ingen `password2` → skal returnere 200
2. `POST /api/register` med `password2: 'forkert'` → skal stadig returnere 422
3. `bundle exec rspec spec/integration/app_spec.rb` → 13 tests, 0 failures

## Checklist
- [x] Tested locally
- [x] OpenAPI spec updated (if endpoint changed) — spec kræver ingen ændring, den var allerede korrekt
- [x] No hardcoded secrets or credentials
- [x] Database migrations work (if applicable) — ingen migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed user registration to correctly handle optional password confirmation field. The registration endpoint now properly validates passwords when the confirmation field is provided, improving flexibility in the signup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->