### PR TITLE
fix(monitoring): hæv Prometheus mem_limit 256m → 512m (OOM crash-loop)

### DIFF
--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -13,7 +13,10 @@ services:
       # Required to reach node_exporter (host network mode) on the same VM
       - "host.docker.internal:host-gateway"
     restart: unless-stopped
-    mem_limit: 256m
+    # 256m var for stramt: working set ligger ~254 MB og head-compaction
+    # spikede over grænsen -> cgroup OOM-kill i loop (54 restarts, bekræftet
+    # i dmesg 2026-06-01). VM2 har ~4 GB, så 512m giver rigelig luft.
+    mem_limit: 512m
     cpus: 0.50
 
   postgres_exporter:


### PR DESCRIPTION
## Problem
Grafana **Operations**-dashboardet loadede ikke alle paneler ordentligt. Live-undersøgelse på Monitoring-VM'en (`monkknows-db`) viste at `monitoring-prometheus-1` var i et **OOM crash-loop**:

- `RestartCount=54` (alle andre monitoring-containere = 0 → container-specifikt, ikke host-reboots; uptime 10 dage).
- Kernens `dmesg` 2026-06-01: gentagne `Memory cgroup out of memory: Killed process … (prometheus)` med `anon-rss ~254 MB` op mod `mem_limit: 256m`. Kills hvert ~30. sekund i en burst (07:18–07:22).
- `docker inspect … OOMKilled=false` var misvisende — flaget afspejler kun den nuværende proces' sidste exit, ikke historikken. dmesg er ground truth.
- Downstream-symptom: TSDB head-chunk-korruption (`chunks_head/000454`, 12. maj) — typisk for SIGKILL midt i en skrivning.

Hver OOM → ~3,5 s WAL-replay hvor `/metrics` + queries fejlede → blanke Grafana-paneler.

## Fix
Hæv Prometheus `mem_limit` **256m → 512m** i `monitoring/docker-compose.monitoring.yml`. VM2 har ~4 GB RAM (2,8 GB ledig, ingen swap), og hele monitoring-stakken bruger reelt < 500 MB — så 512m er sikkert og giver luft til head-compaction-spidserne.

## Verifikation
- [x] Root cause bekræftet i kernens OOM-log
- [x] Sikker headroom verificeret (`free -m` på VM2)
- [ ] Efter merge: `cd-monitoring.yml` deployer; bekræft `RestartCount` holder sig stabilt og `dmesg` ikke logger nye OOM-kills

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced memory allocation for monitoring infrastructure to improve service stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->