### PR TITLE
devops: automatiser project board via PR events

### DIFF
--- a/.github/workflows/project-board.yml
+++ b/.github/workflows/project-board.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, ready_for_review, closed]
 
+permissions: {}
+
+env:
+  PROJECT_ID: "PVT_kwDOD2E2es4BOZ61"
+  STATUS_FIELD_ID: "PVTSSF_lADOD2E2es4BOZ61zg9HgqY"
+
 jobs:
   add-to-review:
     name: Add PR to "In Review"
@@ -21,7 +27,7 @@ jobs:
                 item { id }
               }
             }' \
-            -f project="PVT_kwDOD2E2es4BOZ61" \
+            -f project="$PROJECT_ID" \
             -f pr="$PR_NODE_ID" \
             --jq '.data.addProjectV2ItemById.item.id')
 
@@ -36,9 +42,9 @@ jobs:
                 projectV2Item { id }
               }
             }' \
-            -f project="PVT_kwDOD2E2es4BOZ61" \
+            -f project="$PROJECT_ID" \
             -f item="$ITEM_ID" \
-            -f field="PVTSSF_lADOD2E2es4BOZ61zg9HgqY" \
+            -f field="$STATUS_FIELD_ID" \
             -f option="df73e18b"
 
   mark-as-done:
@@ -56,13 +62,18 @@ jobs:
               node(id: $pr) {
                 ... on PullRequest {
                   projectItems(first: 10) {
-                    nodes { id }
+                    nodes { id project { id } }
                   }
                 }
               }
             }' \
             -f pr="$PR_NODE_ID" \
-            --jq '.data.node.projectItems.nodes[0].id')
+            --jq ".data.node.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id" | head -n1)
+
+          if [ -z "$ITEM_ID" ]; then
+            echo "PR is not on the project board; nothing to update."
+            exit 0
+          fi
 
           gh api graphql -f query='
             mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
@@ -75,7 +86,7 @@ jobs:
                 projectV2Item { id }
               }
             }' \
-            -f project="PVT_kwDOD2E2es4BOZ61" \
+            -f project="$PROJECT_ID" \
             -f item="$ITEM_ID" \
-            -f field="PVTSSF_lADOD2E2es4BOZ61zg9HgqY" \
+            -f field="$STATUS_FIELD_ID" \
             -f option="98236657"

--- a/.github/workflows/project-board.yml
+++ b/.github/workflows/project-board.yml
@@ -1,0 +1,81 @@
+name: Project Board Automation
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, closed]
+
+jobs:
+  add-to-review:
+    name: Add PR to "In Review"
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed' && github.event.pull_request.draft == false
+    steps:
+      - name: Add to project and set "In Review"
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_sobr0002 }}
+          PR_NODE_ID: ${{ github.event.pull_request.node_id }}
+        run: |
+          ITEM_ID=$(gh api graphql -f query='
+            mutation($project: ID!, $pr: ID!) {
+              addProjectV2ItemById(input: {projectId: $project, contentId: $pr}) {
+                item { id }
+              }
+            }' \
+            -f project="PVT_kwDOD2E2es4BOZ61" \
+            -f pr="$PR_NODE_ID" \
+            --jq '.data.addProjectV2ItemById.item.id')
+
+          gh api graphql -f query='
+            mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $project,
+                itemId: $item,
+                fieldId: $field,
+                value: { singleSelectOptionId: $option }
+              }) {
+                projectV2Item { id }
+              }
+            }' \
+            -f project="PVT_kwDOD2E2es4BOZ61" \
+            -f item="$ITEM_ID" \
+            -f field="PVTSSF_lADOD2E2es4BOZ61zg9HgqY" \
+            -f option="df73e18b"
+
+  mark-as-done:
+    name: Mark PR as "Done"
+    runs-on: ubuntu-latest
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    steps:
+      - name: Find project item and set "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_sobr0002 }}
+          PR_NODE_ID: ${{ github.event.pull_request.node_id }}
+        run: |
+          ITEM_ID=$(gh api graphql -f query='
+            query($pr: ID!) {
+              node(id: $pr) {
+                ... on PullRequest {
+                  projectItems(first: 10) {
+                    nodes { id }
+                  }
+                }
+              }
+            }' \
+            -f pr="$PR_NODE_ID" \
+            --jq '.data.node.projectItems.nodes[0].id')
+
+          gh api graphql -f query='
+            mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $project,
+                itemId: $item,
+                fieldId: $field,
+                value: { singleSelectOptionId: $option }
+              }) {
+                projectV2Item { id }
+              }
+            }' \
+            -f project="PVT_kwDOD2E2es4BOZ61" \
+            -f item="$ITEM_ID" \
+            -f field="PVTSSF_lADOD2E2es4BOZ61zg9HgqY" \
+            -f option="98236657"


### PR DESCRIPTION
## Description
Tilføjer et GitHub Actions workflow der automatisk håndterer placering af PRs på vores GitHub Projects board — ingen manuel opdatering nødvendig.

## Related Issue
Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [ ] Documentation
- [x] DevOps / Infrastructure
- [ ] Chore

## Changes Made
- Tilføjer `.github/workflows/project-board.yml` med to jobs:
  - `add-to-review`: trigges på `opened`/`ready_for_review` (ikke-draft) → tilføjer PR til "Legacy Project" board og sætter status til **In Review**
  - `mark-as-done`: trigges på `closed` + `merged == true` → finder eksisterende projekt-item og sætter status til **Done**

## How to Test
1. Opret en ikke-draft PR → verificér at den dukker op på boardet med status "In Review"
2. Merge en PR → verificér at status skifter til "Done"
3. Opret en draft PR → verificér at den **ikke** tilføjes til boardet

## Checklist
- [x] Tested locally
- [x] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [x] Database migrations work (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow to automate project board updates for pull requests. PRs are now automatically added to the project board and marked as "In Review" when opened, and marked as "Done" when merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->