### PR TITLE
docs(monitoring): opdater monitoring-oversigt med recording rules og PR #316-ændringer

### DIFF
--- a/docs/monitoring/monitoring-overview.md
+++ b/docs/monitoring/monitoring-overview.md
@@ -56,6 +56,35 @@ Driftsmetrikker fra app, infrastruktur og database.
 | `node` (vm2) | `host.docker.internal:9100` | Host-metrikker VM2 |
 | `postgres` | `postgres_exporter:9187` | PostgreSQL-metrikker |
 
+Prometheus evaluerer desuden `rules.yml` ved hvert `evaluation_interval` (15s) — se Recording Rules nedenfor.
+
+### Recording Rules (`rules.yml`)
+
+Forudberegner dyre `histogram_quantile`-queries hvert 15. sekund og gemmer resultatet som færdige tidsserier. Løste et problem hvor latency-paneler tog ~84 sekunder at indlæse fordi Prometheus genberegnede over ~200 bucket-serier ved hvert datapunkt (PR #316, 2026-06-01).
+
+| Regel | Hvad | Brugt i panel |
+|---|---|---|
+| `job:http_request_duration_seconds:p50/p95/p99/p999` | Samlet request-latency (alle ruter) | Operations panel #12 |
+| `path:http_request_duration_seconds:p95` | Per-rute latency med `path`-label | Operations panel #13 |
+| `path:app_response_size_bytes:p95` | Response-størrelse per rute | Operations panel #14 |
+| `job:app_weather_api_duration_seconds:p95` | Weather API-latency | Operations panel #18 |
+
+Navneformatet `<aggregation>:<metric>:<function>` følger Prometheus' officielle konvention for recording rules.
+
+> [!NOTE]
+> De forudberegnede serier har kun historik fra det tidspunkt `rules.yml` blev deployet. Rå `*_bucket`-data findes stadig i Prometheus hvis man vil beregne baglæns.
+
+### Resource limits (efter PR #316)
+
+| Service | mem_limit | cpus |
+|---|---|---|
+| `prometheus` | 1024m (↑ fra 256m) | 1.0 (↑ fra 0.50) |
+| `postgres_exporter` | 64m | 0.10 |
+| `node_exporter` | 64m | 0.10 |
+| `grafana` | 384m (↑ fra 256m) | 0.50 |
+
+Prometheus og Grafana var begge i resource-problemer: Prometheus i OOM crash-loop (54 restarts, bekræftet i `dmesg`), Grafana konstant på ~100% af sin 256m-grænse ved tunge dashboard-renders.
+
 ## Discord-alerts (VM1)
 
 `monitor_logs.sh` korer via cron hvert 5. minut og sender Discord-alert ved fund.
@@ -97,8 +126,16 @@ Prometheus maler kun faktiske API-kald, ikke cache-hits. Det betyder:
 - `app_weather_api_duration_seconds` undervurderer den reelle API-belastning hvis man sammenligner med request-raten
 - Det er ikke muligt at se cache hit-rate i Grafana
 
+## Node exporter
+
+`node_exporter` kører på **begge** VMs og leverer CPU/RAM/disk/netværks-metrics:
+
+- **VM2:** kører i `docker-compose.monitoring.yml` (deployes automatisk via `cd-monitoring.yml`)
+- **VM1:** kører via `node_exporter.compose.yml` — deployet manuelt, ingen CD-workflow endnu
+
 ## Hvad der ikke monitoreres
 
-- Host-niveau sikkerhedsaendringer varsles ikke aktivt (Lynis logger, men sender ingen alerts)
+- Host-niveau sikkerhedsændringer varsles ikke aktivt (Lynis logger, men sender ingen alerts)
 - Lynis hardening-score eksponeres ikke til Prometheus/Grafana
-- Lynis-opsaetningen er ikke i CD-pipelinen og vil ga tabt hvis VM1 genoprettes
+- Lynis-opsætningen er ikke i CD-pipelinen og vil gå tabt hvis VM1 genoprettes
+- `node_exporter` på VM1 er manuelt deployet — ikke i CD-pipelinen

--- a/docs/monitoring/monitoring.md
+++ b/docs/monitoring/monitoring.md
@@ -61,6 +61,8 @@ Ud over de tre store er der nogle mindre opdagelser, som er værd at nævne:
 
 - **Manuel server-telemetri afslørede manglende swap.** Før Prometheus var oppe kørte vi en runde manuel telemetri på VM'erne. Ingen kritiske fejl, men VM2 lå på 898 MB RAM uden swap — værd at holde øje med under stress-test ugen før eksamen. Det blinde punkt er siden lukket: `node_exporter` kører på begge VMs og leverer CPU/RAM/disk/netværks-metrics live i Operations-dashboardet, så samme observation i dag ville være automatisk og kontinuerlig i stedet for et øjebliksbillede fra terminalen.
 
+- **Recording rules løste et reelt produktionsproblem.** Operations-dashboardet var ubrugeligt i lange tidsvinduet — latency-paneler tog ~84 sekunder at indlæse fordi `histogram_quantile` genberegnede over ~200 bucket-serier ved hvert datapunkt, hver gang nogen åbnede en visning. PR #316 tilføjede `rules.yml` med forudberegnede percentiler (p50/p95/p99/p99.9) der opdateres hvert 15. sekund, hvilket reducerede indlæsningstiden til millisekunder. Prometheus var samtidig i OOM crash-loop (54 restarts, bekræftet i `dmesg`) og resource limits måtte hæves fra 256m til 1024m. Begge problemer skyldtes at vi ikke havde stresstet dashboardet over et langt tidsvindue inden det gik i produktion — "det ser fint ud lokalt" gælder ikke for systemer der akkumulerer data over tid.
+
 ---
 
 ## Hvad monitoreringen *ikke* gør (endnu)


### PR DESCRIPTION
## Description
Bringer `docs/monitoring/` i sync med den faktiske nuværende tilstand af monitoring-stacken, baseret på kortlægning af kodebasen og PR #316 (recording rules, resource limits).

## Related Issue
Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [x] Documentation
- [ ] DevOps / Infrastructure
- [ ] Chore

## Changes Made
- `monitoring-overview.md`: Tilføjet sektion om Recording Rules (`rules.yml`) med tabel over alle 7 regler og navnekonvention
- `monitoring-overview.md`: Tilføjet Resource limits-tabel med de faktiske værdier efter PR #316 (Prometheus 256m→1024m, Grafana 256m→384m)
- `monitoring-overview.md`: Tilføjet Node exporter-sektion der klargør at den kører på begge VMs (VM2 via CD, VM1 manuelt)
- `monitoring-overview.md`: Rettet stavefejl i "Hvad der ikke monitoreres" + tilføjet node_exporter VM1-mangel
- `monitoring.md`: Tilføjet bullet under "Mindre realiseringer" om recording rules som løste ~84s dashboard-indlæsningstid

## How to Test
1. Læs `docs/monitoring/monitoring-overview.md` og verificer at Recording Rules-sektionen stemmer med `monitoring/rules.yml`
2. Verificer resource limits mod `monitoring/docker-compose.monitoring.yml`
3. Ingen kodeændringer — ingen tests nødvendige

## Checklist
- [x] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)