### PR TITLE
fix: pass CRAWLER_API_KEY to production container

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,6 +29,7 @@ services:
       - DB_NAME=${DB_NAME}
       - SESSION_SECRET=${SESSION_SECRET}
       - OPENWEATHER_API_KEY=${OPENWEATHER_API_KEY}
+      - CRAWLER_API_KEY=${CRAWLER_API_KEY}
     healthcheck:
       test: ["CMD-SHELL", "ruby -e \"require 'net/http'; res = Net::HTTP.get_response(URI('http://localhost:4567/health')); exit(res.is_a?(Net::HTTPSuccess) ? 0 : 1)\" || exit 1"]
       interval: 5s


### PR DESCRIPTION
## Description
`CRAWLER_API_KEY` was written to `.env` on VM1 by the CD pipeline but was never forwarded to the Docker container in `docker-compose.prod.yml`. This caused the app to return `500 - CRAWLER_API_KEY is not configured` when the Azure Function crawler tried to POST scraped pages to `/api/pages`, making every crawl fail.

## Related Issue
Closes #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [ ] Documentation
- [x] DevOps / Infrastructure
- [ ] Chore

## Changes Made
- Add `CRAWLER_API_KEY=${CRAWLER_API_KEY}` to the `environment` section in `docker-compose.prod.yml`

## How to Test
1. Merge PR and wait for CD to deploy
2. Run `./scripts/trigger-crawler.sh` and verify response is `Crawl complete: N pages indexed`
3. Alternatively, check Azure Function logs in Azure Portal for a successful run

## Checklist
- [x] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Production environment configuration updated to support API integration capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->