### PR TITLE
chore: fjern mark-as-done job fra project-board workflow

### DIFF
--- a/.github/workflows/project-board.yml
+++ b/.github/workflows/project-board.yml
@@ -2,7 +2,7 @@ name: Project Board Automation
 
 on:
   pull_request:
-    types: [opened, ready_for_review, closed]
+    types: [opened, ready_for_review]
 
 permissions: {}
 
@@ -14,7 +14,7 @@ jobs:
   add-to-review:
     name: Add PR to "In Review"
     runs-on: ubuntu-latest
-    if: github.event.action != 'closed' && github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     steps:
       - name: Add to project and set "In Review"
         env:
@@ -46,47 +46,3 @@ jobs:
             -f item="$ITEM_ID" \
             -f field="$STATUS_FIELD_ID" \
             -f option="df73e18b"
-
-  mark-as-done:
-    name: Mark PR as "Done"
-    runs-on: ubuntu-latest
-    if: github.event.action == 'closed' && github.event.pull_request.merged == true
-    steps:
-      - name: Find project item and set "Done"
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT_sobr0002 }}
-          PR_NODE_ID: ${{ github.event.pull_request.node_id }}
-        run: |
-          ITEM_ID=$(gh api graphql -f query='
-            query($pr: ID!) {
-              node(id: $pr) {
-                ... on PullRequest {
-                  projectItems(first: 10) {
-                    nodes { id project { id } }
-                  }
-                }
-              }
-            }' \
-            -f pr="$PR_NODE_ID" \
-            --jq ".data.node.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id" | head -n1)
-
-          if [ -z "$ITEM_ID" ]; then
-            echo "PR is not on the project board; nothing to update."
-            exit 0
-          fi
-
-          gh api graphql -f query='
-            mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
-              updateProjectV2ItemFieldValue(input: {
-                projectId: $project,
-                itemId: $item,
-                fieldId: $field,
-                value: { singleSelectOptionId: $option }
-              }) {
-                projectV2Item { id }
-              }
-            }' \
-            -f project="$PROJECT_ID" \
-            -f item="$ITEM_ID" \
-            -f field="$STATUS_FIELD_ID" \
-            -f option="98236657"


### PR DESCRIPTION
## Description
Fjerner det redundante `mark-as-done`-job fra project-board workflowet. GitHub Projects' built-in **"Pull request merged"**-workflow håndterer allerede overgangen til Done ved merge.

## Related Issue
Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [ ] Documentation
- [x] DevOps / Infrastructure
- [ ] Chore

## Changes Made
- Fjerner `mark-as-done`-job fra `.github/workflows/project-board.yml`
- Fjerner `closed` fra trigger-listen (workflowet lytter nu kun på `opened` og `ready_for_review`)

## How to Test
1. Merge en PR → verificér at GitHub Projects' built-in "Pull request merged" workflow sætter status til Done
2. Opret en ny PR → verificér at den stadig havner i "In Review" på boardet

## Checklist
- [x] Tested locally
- [x] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [x] Database migrations work (if applicable)