### PR TITLE
Chore crawler

### DIFF
--- a/azure-function/function_app.py
+++ b/azure-function/function_app.py
@@ -90,6 +90,7 @@ def _fetch_top_search_terms(limit: int = 10) -> list[str]:
         response = requests.get(
             f"{APP_URL}/api/search-logs/top",
             params={"limit": limit},
+            headers={"Authorization": f"Bearer {CRAWLER_API_KEY}"},
             timeout=10,
         )
         response.raise_for_status()

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,6 +29,7 @@ services:
       - DB_NAME=${DB_NAME}
       - SESSION_SECRET=${SESSION_SECRET}
       - OPENWEATHER_API_KEY=${OPENWEATHER_API_KEY}
+      - CRAWLER_API_KEY=${CRAWLER_API_KEY}
     healthcheck:
       test: ["CMD-SHELL", "ruby -e \"require 'net/http'; res = Net::HTTP.get_response(URI('http://localhost:4567/health')); exit(res.is_a?(Net::HTTPSuccess) ? 0 : 1)\" || exit 1"]
       interval: 5s


### PR DESCRIPTION
## Description
Adds authorization header to GET request from crawler in function_app.py in order to get last 10 results from /api/search-log/top. The endpoint is protected

## Related Issue
Closes #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [ ] Documentation
- [x] DevOps / Infrastructure
- [ ] Chore

## Changes Made
 - Add \`CRAWLER_API_KEY=\${CRAWLER_API_KEY}\` to the \`environment\` section in \`docker-compose.prod.yml\`
 - Add \`Authorization: Bearer\` header to \`_fetch_top_search_terms\` in \`azure-function/function_app.py\`

## How to Test
1. Search for a few terms on monkknows.dk to populate the search log
2. Merge PR and wait for CD to deploy the app and Azure Function
3. Run \`./scripts/trigger-crawler.sh\` and verify response is \`Crawl complete: N pages indexed\` where N > 7 (more than seed URLs alone)
4. SSH to VM2 and query: \`SELECT title, url, last_updated FROM pages ORDER BY last_updated DESC LIMIT 15;\` — verify pages with non-seed Wikipedia URLs are present

## Checklist
- [ ] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)
