### PR TITLE
chore: add top-searches and recent-searches helper scripts

### DIFF
--- a/azure-function/function_app.py
+++ b/azure-function/function_app.py
@@ -90,6 +90,7 @@ def _fetch_top_search_terms(limit: int = 10) -> list[str]:
         response = requests.get(
             f"{APP_URL}/api/search-logs/top",
             params={"limit": limit},
+            headers={"Authorization": f"Bearer {CRAWLER_API_KEY}"},
             timeout=10,
         )
         response.raise_for_status()

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,6 +29,7 @@ services:
       - DB_NAME=${DB_NAME}
       - SESSION_SECRET=${SESSION_SECRET}
       - OPENWEATHER_API_KEY=${OPENWEATHER_API_KEY}
+      - CRAWLER_API_KEY=${CRAWLER_API_KEY}
     healthcheck:
       test: ["CMD-SHELL", "ruby -e \"require 'net/http'; res = Net::HTTP.get_response(URI('http://localhost:4567/health')); exit(res.is_a?(Net::HTTPSuccess) ? 0 : 1)\" || exit 1"]
       interval: 5s

--- a/scripts/recent-searches.sh
+++ b/scripts/recent-searches.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Show most recent searches from the MonkKnows database.
+
+LIMIT="${1:-10}"
+
+ssh monkknows-db "docker exec monkknows-db-db-1 psql -U monkknows -d monkknows -c \
+  'SELECT query, result_count, created_at FROM search_logs ORDER BY created_at DESC LIMIT $LIMIT;'"

--- a/scripts/top-searches.sh
+++ b/scripts/top-searches.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Show top search terms from the MonkKnows database.
+
+LIMIT="${1:-10}"
+
+ssh monkknows-db "docker exec monkknows-db-db-1 psql -U monkknows -d monkknows -c \
+  'SELECT query, COUNT(*) AS count FROM search_logs GROUP BY query ORDER BY count DESC LIMIT $LIMIT;'"


### PR DESCRIPTION
## Description
Adds two helper scripts for querying the MonkKnows database directly from the terminal, along with local shell aliases.

## Related Issue
Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [ ] Documentation
- [ ] DevOps / Infrastructure
- [x] Chore

## Changes Made
- Added `scripts/top-searches.sh` — shows top N search terms grouped by count (default 10)
- Added `scripts/recent-searches.sh` — shows N most recent searches with result count and timestamp (default 10)
- Both scripts accept an optional limit argument, e.g. `top-searches 20`

## How to Test
1. Run `source ~/.bashrc`
2. Run `top-searches` — should show top 10 search terms from the database
3. Run `recent-searches` — should show the 10 most recent searches

## Checklist
- [x] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new utility scripts for analyzing search behavior, including tools to retrieve recent searches and identify the most frequently used search terms from the database with configurable result limits.

* **Security**
  * Enhanced the search crawler with API key-based authentication when communicating with the backend service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->