### PR TITLE
fix: crawl dynamic URLs before seed URLs to avoid Wikipedia rate limiting

### DIFF
--- a/azure-function/function_app.py
+++ b/azure-function/function_app.py
@@ -90,6 +90,7 @@ def _fetch_top_search_terms(limit: int = 10) -> list[str]:
         response = requests.get(
             f"{APP_URL}/api/search-logs/top",
             params={"limit": limit},
+            headers={"Authorization": f"Bearer {CRAWLER_API_KEY}"},
             timeout=10,
         )
         response.raise_for_status()

--- a/azure-function/function_app.py
+++ b/azure-function/function_app.py
@@ -78,7 +78,7 @@ def _build_url_list() -> list[str]:
     dynamic_urls = [_wikipedia_url(term) for term in top_terms]
     seen = set()
     result = []
-    for url in SEED_URLS + dynamic_urls:
+    for url in dynamic_urls + SEED_URLS:
         if url not in seen:
             seen.add(url)
             result.append(url)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,6 +29,7 @@ services:
       - DB_NAME=${DB_NAME}
       - SESSION_SECRET=${SESSION_SECRET}
       - OPENWEATHER_API_KEY=${OPENWEATHER_API_KEY}
+      - CRAWLER_API_KEY=${CRAWLER_API_KEY}
     healthcheck:
       test: ["CMD-SHELL", "ruby -e \"require 'net/http'; res = Net::HTTP.get_response(URI('http://localhost:4567/health')); exit(res.is_a?(Net::HTTPSuccess) ? 0 : 1)\" || exit 1"]
       interval: 5s

--- a/scripts/recent-searches.sh
+++ b/scripts/recent-searches.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Show most recent searches from the MonkKnows database.
+
+LIMIT="${1:-10}"
+
+ssh monkknows-db "docker exec monkknows-db-db-1 psql -U monkknows -d monkknows -c \
+  'SELECT query, result_count, created_at FROM search_logs ORDER BY created_at DESC LIMIT $LIMIT;'"

--- a/scripts/top-searches.sh
+++ b/scripts/top-searches.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Show top search terms from the MonkKnows database.
+
+LIMIT="${1:-10}"
+
+ssh monkknows-db "docker exec monkknows-db-db-1 psql -U monkknows -d monkknows -c \
+  'SELECT query, COUNT(*) AS count FROM search_logs GROUP BY query ORDER BY count DESC LIMIT $LIMIT;'"


### PR DESCRIPTION
## Description
Dynamic URLs (from top search terms) are now crawled before seed URLs. Previously, the 8 seed URLs were crawled first, consuming Wikipedia requests and potentially triggering rate limiting before high-priority search terms like "horse" were reached.

## Related Issue
Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [ ] Documentation
- [x] DevOps / Infrastructure
- [ ] Chore

## Changes Made
- Swapped URL order in `_build_url_list()` from `SEED_URLS + dynamic_urls` to `dynamic_urls + SEED_URLS`

## How to Test
1. Merge and wait for CD to deploy the Azure Function
2. Run `trigger-crawler`
3. Check that top search terms (e.g. "horse") are indexed before seed URLs

## Checklist
- [x] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added administrative scripts for monitoring search analytics, providing insights into top-performing queries and recent user searches with configurable result limits

* **Improvements**
  - Strengthened API security by implementing authentication on search telemetry endpoints
  - Refined web crawler URL processing sequence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->