### PR TITLE
docs(sla): update SLA with actual Grafana measurements

### DIFF
--- a/docs/sla.md
+++ b/docs/sla.md
@@ -41,24 +41,18 @@ Følgende er **ikke** dækket af denne SLA:
 | **Månedlig oppetid** | **95 %** |
 | Tilladt nedetid pr. måned | ~36 timer |
 
-95 % er et bevidst konservativt tal. MonkKnows kører på én enkelt Azure VM (App-VM) uden redundans. Deploy via CD-pipelinen medfører en genstart af app-containeren. En oppetidsgaranti på 99 % eller derover ville ikke være realistisk eller ærlig for dette setup.
+Grafana måles til 99,1 % oppetid over de sidste 30 dage. 
+- Manglende server redundans og at vores svartid på hændelses- og gendannelsestider er tidligst næste hverdag, vurderes oppetiden til 95 %.
 
-Planlagt vedligeholdelse (deploys, certifikatfornyelse, database-migrationer) er **inkluderet** i oppetidsberegningen.
+Deployment er **inkluderet** i oppetidsberegningen.
 
 **Måling af oppetid:**
-Prometheus scraper `https://monkknows.dk/metrics` hvert 15. sekund og genererer automatisk en `up`-metrik (`1` = scrape lykkedes, `0` = fejlede). Faktisk månedlig oppetid kan beregnes i Grafana med:
-
-```
-avg_over_time(up{job="monkknows"}[30d])
-```
-
-Dette måler om `/metrics`-endpointet er tilgængeligt og kan bruges som proxy for tjenestens overordnede tilgængelighed. Det er denne måling der skal lægges til grund for at vurdere om 95 %-målet overholdes og for at fastsætte et realistisk tal at love en kunde.
 
 ### Svartid
 
-Konkrete p95-svartidsmål skal defineres på baggrund af faktiske Grafana-målinger (Operations-dashboard, latency-paneler). Tallene opdateres her når baseline er etableret.
-
-Svartider måles fra Prometheus-scrape på `https://monkknows.dk/metrics`.
+Grafana: 
+- 95 % af alle brugere har en svartid under 800 ms. 
+- 99,9 % af alle brugere har en svartid under 1 sek.
 
 ---
 

--- a/docs/sla.md
+++ b/docs/sla.md
@@ -1,6 +1,6 @@
 # Service Level Agreement (SLA) — MonkKnows
 
-_Gyldig fra: 2026-05-17_
+_Gyldig fra: 2026-06-03_
 _Tjeneste: MonkKnows søge- og vejrtjeneste_
 _URL: [https://monkknows.dk](https://monkknows.dk)_
 
@@ -54,6 +54,8 @@ Grafana:
 - 95 % af alle brugere har en svartid under 800 ms. 
 - 99,9 % af alle brugere har en svartid under 1 sek.
 
+Realistisk svartid er derfor 1 sek.
+
 ---
 
 ## 3. Hændelses- og gendannelsesstider
@@ -75,17 +77,17 @@ Grafana:
 
 ## 4. Sikkerhedsforanstaltninger
 
-| Foranstaltning | Detalje |
-|---|---|
+| Foranstaltning | Detalje                                                                                                                                                                                                            |
+|---|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **HTTPS / TLS** | Al trafik krypteres via Let's Encrypt (certifikat på `monkknows.dk` + `www.monkknows.dk`). HTTP (port 80) redirecter automatisk til HTTPS via nginx 301. HSTS aktiveret med `max-age=31536000; includeSubDomains`. |
-| **Sikkerhedsheaders** | `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Content-Security-Policy`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` (camera, microphone, geolocation deaktiveret). |
-| **Brute-force-beskyttelse** | `fail2ban` aktiv på App-VM, banner IP'er ved gentagne fejlede SSH-loginforsøg. |
-| **Session-sikkerhed** | Sessions signeres med `SESSION_SECRET` (krævet i produktion — appen starter ikke uden). Cookies sendes kun over HTTPS. |
-| **Databaseadgang** | PostgreSQL på VM2 er kun tilgængeligt fra App-VM's IP-adresse og et privat subnet (pg_hba.conf whitelist). Adgangskode gemt som Docker secret (`chmod 600`). |
-| **Containerisering** | Appen kører som ikke-root bruger i en multi-stage Docker-container. Ressource-limits: 256 MB RAM og 0,5 CPU for app-containeren. |
-| **Secrets-håndtering** | Ingen hemmeligheder i kode eller Docker-image. CI/CD-pipelinen bygger `.env` fra GitHub Secrets og SCP'er den til serveren ved deploy. |
-| **Sårbarhedsscanning** | Brakeman (statisk analyse), Bundler Audit (kendte sårbarheder i gems) og Trivy (container image scan) køres i CI/CD-pipeline ved hvert PR og deploy. OWASP ZAP køres i CF-pipeline. |
-| **Lynis** | Lynis sikkerhedsaudit kører nightly på App-VM via `lynis.timer`. |
+| **Sikkerhedsheaders** | `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Content-Security-Policy`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` (camera, microphone, geolocation deaktiveret).     |
+| **Brute-force-beskyttelse** | `fail2ban` aktiv på App-VM, banner IP'er ved gentagne fejlede SSH-loginforsøg.                                                                                                                                     |
+| **Session-sikkerhed** | Sessions signeres med `SESSION_SECRET` (krævet i produktion, appen starter ikke uden). Cookies sendes kun over HTTPS.                                                                                              |
+| **Databaseadgang** | PostgreSQL på VM2 er kun tilgængeligt fra App-VM's IP-adresse og et privat subnet (pg_hba.conf whitelist). Adgangskode gemt som Docker secret (`chmod 600`).                                                       |
+| **Containerisering** | Appen kører som ikke-root bruger i en multi-stage Docker-container. Ressource-limits: 256 MB RAM og 0,5 CPU for app-containeren.                                                                                   |
+| **Secrets-håndtering** | Ingen hemmeligheder i kode eller Docker-image. CI/CD-pipelinen bygger `.env` fra GitHub Secrets og SCP'er den til serveren ved deploy.                                                                             |
+| **Sårbarhedsscanning** | Brakeman (statisk analyse), Bundler Audit (kendte sårbarheder i gems) og Trivy (container image scan) køres i CI/CD-pipeline ved hvert PR og deploy. OWASP ZAP køres i CF-pipeline.                                |
+| **Lynis** | Lynis sikkerhedsaudit kører nightly på App-VM via `lynis.timer`.                                                                                                                                                   |
 
 **Kendte begrænsninger:**
 - Grafana-dashboardet er tilgængeligt på port 3000 uden TLS. Det er beskyttet med brugernavn/password, men credentials sendes ukrypteret.
@@ -118,4 +120,4 @@ Spørgsmål om denne SLA eller anmodninger om datasletning kan rettes via GitHub
 
 ---
 
-_Dette dokument er senest revideret: 2026-05-21
+_Dette dokument er senest revideret: 2026-06-02

--- a/docs/sla.md
+++ b/docs/sla.md
@@ -41,12 +41,12 @@ Følgende er **ikke** dækket af denne SLA:
 | **Månedlig oppetid** | **95 %** |
 | Tilladt nedetid pr. måned | ~36 timer |
 
-Grafana måles til 99,1 % oppetid over de sidste 30 dage. 
 - Manglende server redundans og at vores svartid på hændelses- og gendannelsestider er tidligst næste hverdag, vurderes oppetiden til 95 %.
 
 Deployment er **inkluderet** i oppetidsberegningen.
 
 **Måling af oppetid:**
+Grafana måles til 99,1 % oppetid over de sidste 30 dage.
 
 ### Svartid
 


### PR DESCRIPTION
## Description

Updates `docs/sla.md` with actual measured values from Grafana, now that sufficient data is available. Replaces placeholder text and TBD fields with concrete figures.

## Related Issue

Closes #326

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Rewrite (Python → Ruby)
- [x] Documentation
- [ ] DevOps / Infrastructure
- [ ] Chore

## Changes Made

- Adds actual Grafana-measured uptime (99.1% over 30 days) as the basis for the 95% SLO target
- Replaces TBD response time targets with real p95/p99.9 figures from the Operations dashboard (p95 < 800ms, p99.9 < 1s)

## How to Test

1. Open `docs/sla.md` and verify that the figures are present and make sense in context
2. Cross-reference with the Operations dashboard in Grafana to confirm p95/p99.9 values
3. Verify no TBD fields or placeholder text remain

## Checklist

- [x] Tested locally
- [ ] OpenAPI spec updated (if endpoint changed)
- [x] No hardcoded secrets or credentials
- [ ] Database migrations work (if applicable)